### PR TITLE
Fix pcmtrendchart generation on frontend

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -551,6 +551,10 @@ const showOriginalTime = ref(false) // 원본 시간 표시 토글
         const realData = responseData.real_data || []
         console.log('🔧 Real data length:', realData.length)
         console.log('🔧 Response result type:', responseData.result)
+        console.log('🔧 Real data 첫 번째 샘플:', realData[0])
+        if (realData.length > 0) {
+          console.log('🔧 Real data에 PARA 컬럼 있음?', realData[0]?.PARA !== undefined)
+        }
         let result = null
 
         // 결과 타입에 따라 다른 처리

--- a/src/components/PCMTrendChart.vue
+++ b/src/components/PCMTrendChart.vue
@@ -116,7 +116,52 @@ export default defineComponent({
           LSL: 1,
           UCL: 25,
           LCL: 6,
+          PARA: 'PARA_C'
+        },
+        {
+          DATE_WAFER_ID: 6,
+          MIN: 13,
+          MAX: 22,
+          Q1: 16,
+          Q2: 17,
+          Q3: 18,
+          DEVICE: 'A',
+          USL: 30,
+          TGT: 15,
+          LSL: 1,
+          UCL: 25,
+          LCL: 6,
+          PARA: 'PARA_C'
+        },
+        {
+          DATE_WAFER_ID: 7,
+          MIN: 8,
+          MAX: 18,
+          Q1: 14,
+          Q2: 15,
+          Q3: 16,
+          DEVICE: 'C',
+          USL: 30,
+          TGT: 15,
+          LSL: 1,
+          UCL: 25,
+          LCL: 6,
           PARA: 'PARA_A'
+        },
+        {
+          DATE_WAFER_ID: 8,
+          MIN: 14,
+          MAX: 23,
+          Q1: 17,
+          Q2: 18,
+          Q3: 19,
+          DEVICE: 'B',
+          USL: 30,
+          TGT: 15,
+          LSL: 1,
+          UCL: 25,
+          LCL: 6,
+          PARA: 'PARA_C'
         }
       ]
     },
@@ -485,6 +530,8 @@ export default defineComponent({
     }
 
     onMounted(() => {
+      console.log('PCMTrendChart 마운트됨 - 기본 데이터:', props.data)
+      console.log('PCMTrendChart 마운트됨 - PARA 타입들:', paraTypes.value)
       createCharts()
     })
 

--- a/src/components/PCMTrendChart.vue
+++ b/src/components/PCMTrendChart.vue
@@ -189,10 +189,20 @@ export default defineComponent({
 
     // PARA 타입별로 데이터 그룹화
     const paraTypes = computed(() => {
+      if (!props.data || props.data.length === 0) {
+        console.log('PCMTrendChart - 데이터가 없음')
+        return []
+      }
+      
       const types = [...new Set(props.data.map(row => row.PARA).filter(para => para !== undefined && para !== null))]
       console.log('PCMTrendChart - PARA 타입 확인:', types)
       console.log('PCMTrendChart - 전체 데이터 개수:', props.data.length)
       console.log('PCMTrendChart - 첫 번째 데이터 샘플:', props.data[0])
+      
+      // 모든 데이터에 PARA 컬럼이 있는지 확인
+      const hasParaCount = props.data.filter(row => row.PARA !== undefined && row.PARA !== null).length
+      console.log(`PCMTrendChart - PARA 컬럼이 있는 데이터: ${hasParaCount}/${props.data.length}`)
+      
       return types.sort()
     })
 
@@ -456,6 +466,12 @@ export default defineComponent({
     }
 
     const createCharts = async () => {
+      // 데이터가 없거나 유효하지 않으면 차트 생성하지 않음
+      if (!props.data || props.data.length === 0) {
+        console.log('PCMTrendChart: 데이터가 없어서 차트 생성 중단')
+        return
+      }
+
       // 모든 기존 차트 정리
       if (chartContainer.value) {
         Plotly.purge(chartContainer.value)

--- a/src/components/PCMTrendChart.vue
+++ b/src/components/PCMTrendChart.vue
@@ -145,6 +145,9 @@ export default defineComponent({
     // PARA 타입별로 데이터 그룹화
     const paraTypes = computed(() => {
       const types = [...new Set(props.data.map(row => row.PARA).filter(para => para !== undefined && para !== null))]
+      console.log('PCMTrendChart - PARA 타입 확인:', types)
+      console.log('PCMTrendChart - 전체 데이터 개수:', props.data.length)
+      console.log('PCMTrendChart - 첫 번째 데이터 샘플:', props.data[0])
       return types.sort()
     })
 
@@ -422,9 +425,10 @@ export default defineComponent({
 
       if (paraTypes.value.length > 1) {
         // 여러 PARA 타입이 있는 경우 각각 차트 생성
-        console.log(`PCMTrendChart: ${paraTypes.value.length}개의 PARA 타입별 차트 생성`)
+        console.log(`PCMTrendChart: ${paraTypes.value.length}개의 PARA 타입별 차트 생성`, paraTypes.value)
         paraTypes.value.forEach((paraType, index) => {
           const paraData = getParaData(paraType)
+          console.log(`PCMTrendChart: PARA ${paraType} 데이터 개수: ${paraData.length}`)
           const container = chartRefs.value[index]
           if (container && paraData.length > 0) {
             createSingleChart(container, paraData, `${props.title} - PARA: ${paraType}`)
@@ -432,7 +436,7 @@ export default defineComponent({
         })
       } else {
         // 단일 PARA 또는 PARA 컬럼이 없는 경우
-        console.log('PCMTrendChart: 단일 차트 생성')
+        console.log('PCMTrendChart: 단일 차트 생성, PARA 타입:', paraTypes.value)
         if (chartContainer.value) {
           createSingleChart(chartContainer.value, props.data, props.title)
         }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -380,8 +380,13 @@ export const getDefaultPCMData = () => {
 
 // real_data를 활용한 PCM 데이터 생성 (DataFrame JSON 형태)
 export const generatePCMDataWithRealData = (realData) => {
-  // realData가 이미 DataFrame JSON 형태인 경우 그대로 반환
+  // realData가 이미 DataFrame JSON 형태인 경우
   if (Array.isArray(realData)) {
+    console.log('🔧 generatePCMDataWithRealData: 배열 데이터 받음, 길이:', realData.length)
+    if (realData.length > 0) {
+      console.log('🔧 generatePCMDataWithRealData: 첫 번째 데이터:', realData[0])
+      console.log('🔧 generatePCMDataWithRealData: PARA 컬럼 있음?', realData[0]?.PARA !== undefined)
+    }
     return realData
   }
   

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -237,7 +237,8 @@ export const getDefaultPCMData = () => {
       TGT: 15,
       LSL: 1,
       UCL: 25,
-      LCL: 6
+      LCL: 6,
+      PARA: 'PARA_A'
     },
     {
       DATE_WAFER_ID: 2,
@@ -251,7 +252,8 @@ export const getDefaultPCMData = () => {
       TGT: 15,
       LSL: 1,
       UCL: 25,
-      LCL: 6
+      LCL: 6,
+      PARA: 'PARA_A'
     },
     {
       DATE_WAFER_ID: 3,
@@ -265,7 +267,8 @@ export const getDefaultPCMData = () => {
       TGT: 15,
       LSL: 1,
       UCL: 25,
-      LCL: 6
+      LCL: 6,
+      PARA: 'PARA_B'
     },
     {
       DATE_WAFER_ID: 4,
@@ -279,7 +282,8 @@ export const getDefaultPCMData = () => {
       TGT: 15,
       LSL: 1,
       UCL: 25,
-      LCL: 6
+      LCL: 6,
+      PARA: 'PARA_B'
     },
     {
       DATE_WAFER_ID: 5,
@@ -293,7 +297,8 @@ export const getDefaultPCMData = () => {
       TGT: 15,
       LSL: 1,
       UCL: 25,
-      LCL: 6
+      LCL: 6,
+      PARA: 'PARA_A'
     },
     {
       DATE_WAFER_ID: 6,
@@ -307,7 +312,8 @@ export const getDefaultPCMData = () => {
       TGT: 15,
       LSL: 1,
       UCL: 25,
-      LCL: 6
+      LCL: 6,
+      PARA: 'PARA_A'
     },
     {
       DATE_WAFER_ID: 7,
@@ -321,7 +327,8 @@ export const getDefaultPCMData = () => {
       TGT: 15,
       LSL: 1,
       UCL: 25,
-      LCL: 6
+      LCL: 6,
+      PARA: 'PARA_C'
     },
     {
       DATE_WAFER_ID: 8,
@@ -335,7 +342,8 @@ export const getDefaultPCMData = () => {
       TGT: 15,
       LSL: 1,
       UCL: 25,
-      LCL: 6
+      LCL: 6,
+      PARA: 'PARA_C'
     },
     {
       DATE_WAFER_ID: 9,
@@ -349,7 +357,8 @@ export const getDefaultPCMData = () => {
       TGT: 15,
       LSL: 1,
       UCL: 25,
-      LCL: 6
+      LCL: 6,
+      PARA: 'PARA_B'
     },
     {
       DATE_WAFER_ID: 10,
@@ -363,7 +372,8 @@ export const getDefaultPCMData = () => {
       TGT: 15,
       LSL: 1,
       UCL: 25,
-      LCL: 6
+      LCL: 6,
+      PARA: 'PARA_C'
     }
   ]
 }
@@ -392,7 +402,8 @@ export const generatePCMDataWithRealData = (realData) => {
       TGT: row.TGT,
       LSL: row.LSL,
       UCL: row.UCL,
-      LCL: row.LCL
+      LCL: row.LCL,
+      PARA: row.PARA
     }
   })
 }
@@ -421,7 +432,8 @@ export const generateCommonalityDataWithRealData = (realData, determinedData) =>
         TGT: row.TGT,
         LSL: row.LSL,
         UCL: row.UCL,
-        LCL: row.LCL
+        LCL: row.LCL,
+        PARA: row.PARA
       }
     })
   }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -380,6 +380,32 @@ export const getDefaultPCMData = () => {
 
 // real_data를 활용한 PCM 데이터 생성 (DataFrame JSON 형태)
 export const generatePCMDataWithRealData = (realData) => {
+  console.log('🔧 generatePCMDataWithRealData 받은 데이터:', realData)
+  
+  // realData가 객체 형태인 경우 {para1: [data], para2: [data], ...}
+  if (realData && typeof realData === 'object' && !Array.isArray(realData)) {
+    console.log('🔧 PARA별 객체 데이터 감지:', Object.keys(realData))
+    
+    const combinedData = []
+    
+    // 각 PARA별 데이터를 합치면서 PARA 컬럼 추가
+    Object.keys(realData).forEach(paraName => {
+      const paraData = realData[paraName]
+      if (Array.isArray(paraData)) {
+        console.log(`🔧 PARA ${paraName}: ${paraData.length}개 데이터`)
+        paraData.forEach(row => {
+          combinedData.push({
+            ...row,
+            PARA: paraName
+          })
+        })
+      }
+    })
+    
+    console.log('🔧 합쳐진 데이터 총 개수:', combinedData.length)
+    return combinedData
+  }
+  
   // realData가 이미 DataFrame JSON 형태인 경우
   if (Array.isArray(realData)) {
     console.log('🔧 generatePCMDataWithRealData: 배열 데이터 받음, 길이:', realData.length)


### PR DESCRIPTION
Correct PCMTrendChart to generate separate charts for each PARA type.

The `PARA` column was missing or not correctly propagated in the data used by `PCMTrendChart`, preventing it from identifying and grouping data by `PARA` type. This PR ensures the `PARA` column is included in default and generated data, and updates the component's test data and logging for verification.

---

[Open in Web](https://www.cursor.com/agents?id=bc-80a1ebce-c464-410c-a11e-b8de61bed3b5) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-80a1ebce-c464-410c-a11e-b8de61bed3b5)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)