### PR TITLE
Pcm trend chart sorting

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1412,13 +1412,11 @@ const showOriginalTime = ref(false) // 원본 시간 표시 토글
           }
         } else if (responseData.result === 'lot_point') {
           // PCM 트렌드 포인트 데이터 처리
-          // sort_criteria가 추가로 내려오는 경우를 위해 data를 wrapper 형태로 전달 (backward compatible)
-          const sortCriteria = responseData.sort_criteria || responseData.sortCriteria
           result = {
             id: `history_${chatId}_${Date.now()}`,
             type: 'pcm_trend_point',
             title: `PCM Trend Point Chart`,
-            data: sortCriteria ? { real_data: realData, sort_criteria: sortCriteria } : realData,
+            data: realData,
             isActive: false,
             timestamp: new Date(),
             chatId: chatId,
@@ -2258,7 +2256,6 @@ const showOriginalTime = ref(false) // 원본 시간 표시 토글
             } else if (data.response.result === 'lot_point') {
               // PCM 트렌드 포인트 데이터 처리
               const realData = data.response.real_data
-              const sortCriteria = data.response.sort_criteria || data.response.sortCriteria
               
               // real_data가 없으면 analysis report 탭을 생성하지 않음
               if (!realData || (Array.isArray(realData) && realData.length === 0)) {
@@ -2273,7 +2270,7 @@ const showOriginalTime = ref(false) // 원본 시간 표시 토글
                 id: data.response_id || `local_${Date.now()}`, // 백엔드에서 받는 response_id 사용
                 type: 'pcm_trend_point',
                 title: `PCM Trend Point Chart`,
-                data: sortCriteria ? { real_data: realData, sort_criteria: sortCriteria } : realData,
+                data: realData,
                 isActive: true,
                 timestamp: new Date(),
                 chatId: data.chat_id,

--- a/src/App.vue
+++ b/src/App.vue
@@ -1411,11 +1411,13 @@ const showOriginalTime = ref(false) // 원본 시간 표시 토글
           }
         } else if (responseData.result === 'lot_point') {
           // PCM 트렌드 포인트 데이터 처리
+          // sort_criteria가 추가로 내려오는 경우를 위해 data를 wrapper 형태로 전달 (backward compatible)
+          const sortCriteria = responseData.sort_criteria || responseData.sortCriteria
           result = {
             id: `history_${chatId}_${Date.now()}`,
             type: 'pcm_trend_point',
             title: `PCM Trend Point Chart`,
-            data: realData,
+            data: sortCriteria ? { real_data: realData, sort_criteria: sortCriteria } : realData,
             isActive: false,
             timestamp: new Date(),
             chatId: chatId,
@@ -2254,6 +2256,7 @@ const showOriginalTime = ref(false) // 원본 시간 표시 토글
             } else if (data.response.result === 'lot_point') {
               // PCM 트렌드 포인트 데이터 처리
               const realData = data.response.real_data
+              const sortCriteria = data.response.sort_criteria || data.response.sortCriteria
               
               // real_data가 없으면 analysis report 탭을 생성하지 않음
               if (!realData || (Array.isArray(realData) && realData.length === 0)) {
@@ -2268,7 +2271,7 @@ const showOriginalTime = ref(false) // 원본 시간 표시 토글
                 id: data.response_id || `local_${Date.now()}`, // 백엔드에서 받는 response_id 사용
                 type: 'pcm_trend_point',
                 title: `PCM Trend Point Chart`,
-                data: realData,
+                data: sortCriteria ? { real_data: realData, sort_criteria: sortCriteria } : realData,
                 isActive: true,
                 timestamp: new Date(),
                 chatId: data.chat_id,

--- a/src/App.vue
+++ b/src/App.vue
@@ -1395,12 +1395,13 @@ const showOriginalTime = ref(false) // 원본 시간 표시 토글
         // 결과 타입에 따라 다른 처리
         if (responseData.result === 'lot_start') {
           // PCM 트렌드 데이터 처리
+          const sortCriteria = responseData.sort_criteria || responseData.sortCriteria
           const chartData = generatePCMDataWithRealData(realData)
           result = {
             id: `history_${chatId}_${Date.now()}`,
             type: 'pcm_trend',
             title: `PCM Trend Analysis`,
-            data: chartData,
+            data: sortCriteria ? { real_data: chartData, sort_criteria: sortCriteria } : chartData,
             isActive: false,
             timestamp: new Date(),
             chatId: chatId,
@@ -2219,6 +2220,7 @@ const showOriginalTime = ref(false) // 원본 시간 표시 토글
             } else if (data.response.result === 'lot_start') {
               // PCM 트렌드 데이터 처리
               const realData = data.response.real_data || []
+              const sortCriteria = data.response.sort_criteria || data.response.sortCriteria
               if (realData.length === 0) {
                 // real_data가 없으면 analysis report 탭을 생성하지 않음
                 return
@@ -2233,7 +2235,7 @@ const showOriginalTime = ref(false) // 원본 시간 표시 토글
                 id: data.response_id || `local_${Date.now()}`, // 백엔드에서 받는 response_id 사용
                 type: 'pcm_trend',
                 title: `PCM Trend Analysis`,
-                data: chartData,
+                data: sortCriteria ? { real_data: chartData, sort_criteria: sortCriteria } : chartData,
                 isActive: true,
                 timestamp: new Date(),
                 chatId: data.chat_id,

--- a/src/components/PCMTrendChart.vue
+++ b/src/components/PCMTrendChart.vue
@@ -480,10 +480,47 @@ export default defineComponent({
       // Combine all traces
       const allTraces = [...boxTraces, ...scatterTraces]
 
+      const formatMaybeDate = (value) => {
+        if (value === null || value === undefined) return 'N/A'
+        const str = String(value)
+        // e.g. "2025-06-1:36:57:54_A..." or "2025-06-01 ..."
+        const match = str.match(/^(\d{4}-\d{2}-\d{1,2})/)
+        if (match) return match[1]
+        return str
+      }
+
+      const formatSpecValue = (value) => {
+        const num = coerceNumber(value)
+        if (num === null) return 'N/A'
+        if (Number.isInteger(num)) return String(num)
+        // up to 4 decimals, trim trailing zeros
+        return String(Number(num.toFixed(4)))
+      }
+
+      const pickFirstFinite = (rows, field) => {
+        for (const row of rows) {
+          const val = coerceNumber(row?.[field])
+          if (val !== null) return val
+        }
+        return null
+      }
+
+      const fromVal = xOrder.length ? formatMaybeDate(xOrder[0]) : 'N/A'
+      const toVal = xOrder.length ? formatMaybeDate(xOrder[xOrder.length - 1]) : 'N/A'
+      const uslVal = formatSpecValue(pickFirstFinite(sorted, 'USL'))
+      const tgtVal = formatSpecValue(pickFirstFinite(sorted, 'TGT'))
+      const lslVal = formatSpecValue(pickFirstFinite(sorted, 'LSL'))
+
+      // PARA 이름은 chartTitle에 포함된 "PARA: xxx"가 있으면 우선 사용, 없으면 props.title 사용
+      const paraMatch = String(chartTitle || '').match(/PARA:\s*([^\s<]+)\s*$/)
+      const paraLabel = paraMatch ? paraMatch[1] : (paraTypes.value.length === 1 ? paraTypes.value[0] : null)
+      const baseTitle = paraLabel ? `${paraLabel} PCM Trend` : (chartTitle || props.title)
+      const fullTitle = `${baseTitle}<br>From: ${fromVal}    To: ${toVal}<br>USL : (${uslVal}) - TGT : (${tgtVal}) - LSL : (${lslVal})`
+
       // Layout configuration
       const layout = {
         title: {
-          text: chartTitle || props.title,
+          text: fullTitle,
           font: {
             size: 16,
             color: '#333'

--- a/src/components/PCMTrendChart.vue
+++ b/src/components/PCMTrendChart.vue
@@ -25,7 +25,7 @@
       <div v-if="paraTypes.length === 1" class="para-chart-header">
         <h3>{{ title }} - PARA: {{ paraTypes[0] }}</h3>
         <div class="para-chart-info">
-          <span class="data-count">{{ data.length }} records</span>
+          <span class="data-count">{{ getDisplayData().length }} records</span>
         </div>
       </div>
       <div ref="chartContainer" class="chart-container"></div>
@@ -41,7 +41,7 @@ export default defineComponent({
   name: 'PCMTrendChart',
   props: {
     data: {
-      type: Array,
+      type: [Array, Object],
       default: () => [
         {
           DATE_WAFER_ID: 1,
@@ -187,27 +187,110 @@ export default defineComponent({
     const chartRefs = ref([])
     const columns = ['DATE_WAFER_ID', 'MIN', 'MAX', 'Q1', 'Q2', 'Q3', 'DEVICE', 'USL', 'TGT', 'LSL', 'UCL', 'LCL', 'PARA']
 
+    const VALID_SORT_CRITERIA = ['TIMELY', 'DEVICE', 'TEST_EQ']
+
+    const coerceNumber = (value) => {
+      if (value === null || value === undefined) return null
+      if (typeof value === 'number') return Number.isFinite(value) ? value : null
+      const parsed = Number(value)
+      return Number.isFinite(parsed) ? parsed : null
+    }
+
+    const compareMaybeNumeric = (a, b) => {
+      const aNum = coerceNumber(a)
+      const bNum = coerceNumber(b)
+      if (aNum !== null && bNum !== null) return aNum - bNum
+      return String(a ?? '').localeCompare(String(b ?? ''), undefined, { numeric: true, sensitivity: 'base' })
+    }
+
+    const uniqueInOrder = (arr) => {
+      const seen = new Set()
+      const out = []
+      arr.forEach((v) => {
+        const key = v === null || v === undefined ? '__missing__' : String(v)
+        if (!seen.has(key)) {
+          seen.add(key)
+          out.push(v)
+        }
+      })
+      return out
+    }
+
+    /**
+     * lot_start 응답이 아래처럼 와도 안전하게 처리:
+     * - Array rows
+     * - { real_data: <rows|para-map>, sort_criteria: '...' }
+     * - { PARA1: [...], PARA2: [...], sort_criteria: '...' }
+     */
+    const extractPayload = (input) => {
+      let sortCriteria = null
+      let source = input
+
+      if (!source) return { rows: [], sortCriteria }
+
+      if (typeof source === 'object' && !Array.isArray(source)) {
+        if (source.sort_criteria) sortCriteria = source.sort_criteria
+        if (source.sortCriteria) sortCriteria = source.sortCriteria
+        if (source.real_data !== undefined) source = source.real_data
+      }
+
+      if (Array.isArray(source)) {
+        if (source.length === 0) return { rows: [], sortCriteria }
+        // legacy: [ [rows] ]
+        if (Array.isArray(source[0])) return { rows: source[0], sortCriteria }
+        return { rows: source, sortCriteria }
+      }
+
+      if (source && typeof source === 'object') {
+        const keys = Object.keys(source)
+        const merged = []
+        keys.forEach((key) => {
+          const value = source[key]
+          if (Array.isArray(value)) {
+            value.forEach((row) => merged.push({ ...(row || {}), PARA: key }))
+          }
+        })
+        return { rows: merged, sortCriteria }
+      }
+
+      return { rows: [], sortCriteria }
+    }
+
+    const sortCriteria = computed(() => {
+      const payload = extractPayload(props.data)
+      const raw = payload.sortCriteria
+      if (typeof raw !== 'string') return 'TIMELY'
+      const upper = raw.toUpperCase()
+      return VALID_SORT_CRITERIA.includes(upper) ? upper : 'TIMELY'
+    })
+
+    const getDisplayData = () => {
+      const payload = extractPayload(props.data)
+      return payload.rows || []
+    }
+
     // PARA 타입별로 데이터 그룹화
     const paraTypes = computed(() => {
-      if (!props.data || props.data.length === 0) {
+      const rows = getDisplayData()
+      if (!rows || rows.length === 0) {
         console.log('PCMTrendChart - 데이터가 없음')
         return []
       }
       
-      const types = [...new Set(props.data.map(row => row.PARA).filter(para => para !== undefined && para !== null))]
+      const types = [...new Set(rows.map(row => row.PARA).filter(para => para !== undefined && para !== null))]
       console.log('PCMTrendChart - PARA 타입 확인:', types)
-      console.log('PCMTrendChart - 전체 데이터 개수:', props.data.length)
-      console.log('PCMTrendChart - 첫 번째 데이터 샘플:', props.data[0])
+      console.log('PCMTrendChart - 전체 데이터 개수:', rows.length)
+      console.log('PCMTrendChart - 첫 번째 데이터 샘플:', rows[0])
       
       // 모든 데이터에 PARA 컬럼이 있는지 확인
-      const hasParaCount = props.data.filter(row => row.PARA !== undefined && row.PARA !== null).length
-      console.log(`PCMTrendChart - PARA 컬럼이 있는 데이터: ${hasParaCount}/${props.data.length}`)
+      const hasParaCount = rows.filter(row => row.PARA !== undefined && row.PARA !== null).length
+      console.log(`PCMTrendChart - PARA 컬럼이 있는 데이터: ${hasParaCount}/${rows.length}`)
       
       return types.sort()
     })
 
     const getParaData = (paraType) => {
-      return props.data.filter(row => row.PARA === paraType)
+      return getDisplayData().filter(row => row.PARA === paraType)
     }
 
     const setChartRef = (el, index) => {
@@ -219,6 +302,12 @@ export default defineComponent({
     // Helper function to generate data points for box plots
     const generateBoxPlotData = (min, q1, q2, q3, max, count = 30) => {
       const data = []
+      const minVal = coerceNumber(min)
+      const q1Val = coerceNumber(q1)
+      const q2Val = coerceNumber(q2)
+      const q3Val = coerceNumber(q3)
+      const maxVal = coerceNumber(max)
+      if ([minVal, q1Val, q2Val, q3Val, maxVal].some(v => v === null)) return []
       
       // Generate data points within each quartile
       const q1Count = Math.floor(count * 0.25)
@@ -228,22 +317,22 @@ export default defineComponent({
       
       // Q1 range (min to q1)
       for (let i = 0; i < q1Count; i++) {
-        data.push(min + Math.random() * (q1 - min))
+        data.push(minVal + Math.random() * (q1Val - minVal))
       }
       
       // Q2 range (q1 to q2)
       for (let i = 0; i < q2Count; i++) {
-        data.push(q1 + Math.random() * (q2 - q1))
+        data.push(q1Val + Math.random() * (q2Val - q1Val))
       }
       
       // Q3 range (q2 to q3)
       for (let i = 0; i < q3Count; i++) {
-        data.push(q2 + Math.random() * (q3 - q2))
+        data.push(q2Val + Math.random() * (q3Val - q2Val))
       }
       
       // Q4 range (q3 to max)
       for (let i = 0; i < q4Count; i++) {
-        data.push(q3 + Math.random() * (max - q3))
+        data.push(q3Val + Math.random() * (maxVal - q3Val))
       }
       
       return data
@@ -254,149 +343,139 @@ export default defineComponent({
 
       console.log(`PCMTrendChart 차트 생성: ${chartTitle || 'Default'} - ${data.length}개 데이터`)
 
-      // Extract data for control lines
-      const dateWaferIds = data.map(row => row.DATE_WAFER_ID)
-      const usls = data.map(row => row.USL)
-      const tgts = data.map(row => row.TGT)
-      const lsls = data.map(row => row.LSL)
-      const ucls = data.map(row => row.UCL)
-      const lcls = data.map(row => row.LCL)
+      const currentSort = sortCriteria.value
+      const colorField = currentSort === 'TEST_EQ' ? 'TEST_EQ' : 'DEVICE' // TIMELY/DEVICE는 DEVICE 고정
+      const resolvedColorField = data.some(row => row && row[colorField] !== undefined) ? colorField : 'DEVICE'
 
-      // x축 라벨 생성 (적절한 간격으로 표시)
-      const xOrder = [...new Set(dateWaferIds)].sort((a, b) => a - b)
-      const maxLabels = 50
-      const step = Math.max(1, Math.floor(xOrder.length / maxLabels))
-      const sampledLabels = xOrder.filter((_, index) => index % step === 0)
+      // 파이썬 로직과 동일한 정렬: TIMELY => DATE, DEVICE/TEST_EQ => (criteria, DATE)
+      const sorted = [...data].sort((a, b) => {
+        if (currentSort === 'DEVICE' || currentSort === 'TEST_EQ') {
+          const aKey = a?.[currentSort]
+          const bKey = b?.[currentSort]
+          const cmpKey = String(aKey ?? '').localeCompare(String(bKey ?? ''), undefined, { numeric: true, sensitivity: 'base' })
+          if (cmpKey !== 0) return cmpKey
+        }
+        return compareMaybeNumeric(a?.DATE_WAFER_ID, b?.DATE_WAFER_ID)
+      })
 
-      // Create box plot traces for each device
-      const deviceTypes = [...new Set(data.map(row => row.DEVICE))]
-      const boxTraces = []
-      
-      deviceTypes.forEach(device => {
-        const deviceData = data.filter(row => row.DEVICE === device)
-        
-        // Generate box plot data for each date point
+      // x축 카테고리 순서(등장 순서 유지)
+      const xOrder = uniqueInOrder(sorted.map(row => row?.DATE_WAFER_ID))
+
+      const maxLabels = props.maxLabels || 50
+      const labelStep = Math.max(1, Math.floor(xOrder.length / maxLabels))
+      const sampledLabels = xOrder.filter((_, index) => index % labelStep === 0)
+
+      // 그룹(색상) 키 목록
+      const groupKeys = uniqueInOrder(sorted.map(row => row?.[resolvedColorField]))
+
+      // Create box plot traces for each group (DEVICE or TEST_EQ)
+      const boxTraces = groupKeys.map(groupKey => {
+        const groupRows = sorted.filter(row => row?.[resolvedColorField] === groupKey)
         const allBoxData = []
         const allLabels = []
-        
-        deviceData.forEach(row => {
-          const boxData = generateBoxPlotData(
-            row.MIN, 
-            row.Q1, 
-            row.Q2, 
-            row.Q3, 
-            row.MAX
-          )
+
+        groupRows.forEach(row => {
+          const boxData = generateBoxPlotData(row.MIN, row.Q1, row.Q2, row.Q3, row.MAX)
+          if (!boxData.length) return
           allBoxData.push(...boxData)
           allLabels.push(...Array(boxData.length).fill(row.DATE_WAFER_ID))
         })
 
-        boxTraces.push({
+        if (!allBoxData.length) return null
+
+        return {
           type: 'box',
           x: allLabels,
           y: allBoxData,
-          name: `Device ${device}`,
+          name: `${resolvedColorField} ${groupKey}`,
           boxpoints: 'outliers',
           jitter: 0.3,
           pointpos: -1.8,
           marker: {
-            color: getDeviceColor(device),
+            color: getSeriesColor(groupKey),
             size: 4
           },
           line: {
-            color: getDeviceColor(device),
+            color: getSeriesColor(groupKey),
             width: 2
           },
-          fillcolor: getDeviceColor(device, 0.4),
+          fillcolor: getSeriesColor(groupKey, 0.4),
           showlegend: true
-        })
+        }
+      }).filter(Boolean)
+
+      // control line: 날짜별 첫 row를 사용 (중복 x 방지)
+      const firstRowByDate = new Map()
+      sorted.forEach((row) => {
+        const key = row?.DATE_WAFER_ID
+        if (!firstRowByDate.has(key)) firstRowByDate.set(key, row)
       })
 
-      // Create scatter traces for control lines
-      const scatterTraces = [
-        {
+      const seriesByDate = (field) => xOrder.map((date) => coerceNumber(firstRowByDate.get(date)?.[field]))
+      const shouldDrawLine = (arr) => arr.some(v => typeof v === 'number' && Number.isFinite(v))
+
+      const usls = seriesByDate('USL')
+      const tgts = seriesByDate('TGT')
+      const lsls = seriesByDate('LSL')
+      const ucls = seriesByDate('UCL')
+      const lcls = seriesByDate('LCL')
+
+      const scatterTraces = []
+      if (shouldDrawLine(usls)) {
+        scatterTraces.push({
           type: 'scatter',
-          x: dateWaferIds,
+          x: xOrder,
           y: usls,
           mode: 'lines',
           name: 'USL',
-          line: { 
-            color: 'rgba(0, 0, 0, 0.8)',
-            width: 2
-          },
-          marker: {
-            color: 'rgba(0, 0, 0, 0.8)',
-            size: 4
-          },
+          line: { color: 'rgba(255, 0, 0, 0.8)', width: 2 },
           showlegend: true
-        },
-        {
+        })
+      }
+      if (shouldDrawLine(tgts)) {
+        scatterTraces.push({
           type: 'scatter',
-          x: dateWaferIds,
+          x: xOrder,
           y: tgts,
           mode: 'lines',
           name: 'TGT',
-          line: { 
-            color: 'rgba(0, 0, 0, 0.5)',
-            width: 2
-          },
-          marker: {
-            color: 'rgba(0, 0, 0, 0.5)',
-            size: 4
-          },
+          line: { color: 'rgba(0, 0, 0, 0.5)', width: 2 },
           showlegend: true
-        },
-        {
+        })
+      }
+      if (shouldDrawLine(lsls)) {
+        scatterTraces.push({
           type: 'scatter',
-          x: dateWaferIds,
+          x: xOrder,
           y: lsls,
           mode: 'lines',
           name: 'LSL',
-          line: { 
-            color: 'rgba(0, 0, 0, 0.8)',
-            width: 2
-          },
-          marker: {
-            color: 'rgba(0, 0, 0, 0.8)',
-            size: 4
-          },
+          line: { color: 'rgba(255, 0, 0, 0.8)', width: 2 },
           showlegend: true
-        },
-        {
+        })
+      }
+      if (shouldDrawLine(ucls)) {
+        scatterTraces.push({
           type: 'scatter',
-          x: dateWaferIds,
+          x: xOrder,
           y: ucls,
           mode: 'lines',
           name: 'UCL',
-          line: { 
-            color: 'rgba(255, 128, 10, 0.5)',
-            width: 2,
-            dash: 'dash'
-          },
-          marker: {
-            color: 'rgba(255, 128, 10, 0.5)',
-            size: 4
-          },
+          line: { color: 'rgba(255, 128, 10, 0.5)', width: 2, dash: 'dash' },
           showlegend: true
-        },
-        {
+        })
+      }
+      if (shouldDrawLine(lcls)) {
+        scatterTraces.push({
           type: 'scatter',
-          x: dateWaferIds,
+          x: xOrder,
           y: lcls,
           mode: 'lines',
           name: 'LCL',
-          line: { 
-            color: 'rgba(255, 128, 10, 0.5)',
-            width: 2,
-            dash: 'dash'
-          },
-          marker: {
-            color: 'rgba(255, 128, 10, 0.5)',
-            size: 4
-          },
+          line: { color: 'rgba(255, 128, 10, 0.5)', width: 2, dash: 'dash' },
           showlegend: true
-        }
-      ]
+        })
+      }
 
       // Combine all traces
       const allTraces = [...boxTraces, ...scatterTraces]
@@ -436,6 +515,7 @@ export default defineComponent({
           gridcolor: '#f0f0f0'
         },
         height: props.height,
+        boxmode: 'overlay',
         showlegend: true,
         legend: {
           orientation: 'v', 
@@ -470,7 +550,8 @@ export default defineComponent({
 
     const createCharts = async () => {
       // 데이터가 없거나 유효하지 않으면 차트 생성하지 않음
-      if (!props.data || props.data.length === 0) {
+      const rows = getDisplayData()
+      if (!rows || rows.length === 0) {
         console.log('PCMTrendChart: 데이터가 없어서 차트 생성 중단')
         return
       }
@@ -502,13 +583,13 @@ export default defineComponent({
         // 단일 PARA 또는 PARA 컬럼이 없는 경우
         console.log('PCMTrendChart: 단일 차트 생성, PARA 타입:', paraTypes.value)
         if (chartContainer.value) {
-          createSingleChart(chartContainer.value, props.data, props.title)
+          createSingleChart(chartContainer.value, rows, props.title)
         }
       }
     }
 
-    // Helper function to get colors for different devices
-    const getDeviceColor = (device, alpha = 1) => {
+    // Helper function to get colors for groups (DEVICE/TEST_EQ)
+    const getSeriesColor = (groupKey, alpha = 1) => {
       const colorPalette = [
         [102, 126, 234], // 블루
         [118, 75, 162],  // 퍼플
@@ -532,17 +613,18 @@ export default defineComponent({
         [189, 195, 199]  // 베이지
       ]
       
-      const getDeviceIndex = (deviceName) => {
+      const getIndex = (name) => {
         let hash = 0
-        for (let i = 0; i < deviceName.toString().length; i++) {
-          const char = deviceName.toString().charCodeAt(i)
+        const str = (name === null || name === undefined) ? 'Series' : name.toString()
+        for (let i = 0; i < str.length; i++) {
+          const char = str.charCodeAt(i)
           hash = ((hash << 5) - hash) + char
           hash = hash & hash
         }
         return Math.abs(hash) % colorPalette.length
       }
       
-      const colorIndex = getDeviceIndex(device)
+      const colorIndex = getIndex(groupKey)
       const [r, g, b] = colorPalette[colorIndex]
       
       return `rgba(${r}, ${g}, ${b}, ${alpha})`
@@ -564,6 +646,7 @@ export default defineComponent({
       chartContainer,
       chartRefs,
       paraTypes,
+      getDisplayData,
       getParaData,
       setChartRef
     }

--- a/src/components/PCMTrendPointChart.vue
+++ b/src/components/PCMTrendPointChart.vue
@@ -100,160 +100,6 @@ export default defineComponent({
     const chartContainer = ref(null)
     const chartRefs = ref([])
 
-    const VALID_SORT_CRITERIA = ['TIMELY', 'DEVICE', 'TEST_EQ']
-
-    /**
-     * backend payload가 아래처럼 바뀌어도 견고하게 처리:
-     * - Array rows
-     * - { real_data: <rows|para-map>, sort_criteria: '...' }
-     * - { PARA1: [...], PARA2: [...], sort_criteria: '...' }
-     * - { real_data: { PARA1: [...], ... }, sort_criteria: '...' }
-     */
-    const extractPayload = (input) => {
-      let sortCriteria = null
-      let source = input
-
-      if (!source) return { rows: [], sortCriteria }
-
-      // wrapper: { real_data, sort_criteria }
-      if (typeof source === 'object' && !Array.isArray(source)) {
-        if (source.sort_criteria) sortCriteria = source.sort_criteria
-        if (source.sortCriteria) sortCriteria = source.sortCriteria
-
-        if (source.real_data !== undefined) {
-          source = source.real_data
-        }
-      }
-
-      // wrapper: { real_data: { ... } } 형태가 한 번 더 중첩될 수 있음
-      if (source && typeof source === 'object' && !Array.isArray(source) && source.real_data !== undefined) {
-        if (!sortCriteria && source.sort_criteria) sortCriteria = source.sort_criteria
-        if (!sortCriteria && source.sortCriteria) sortCriteria = source.sortCriteria
-        source = source.real_data
-      }
-
-      // Array 형태
-      if (Array.isArray(source)) {
-        if (source.length === 0) return { rows: [], sortCriteria }
-        // legacy: [ [rows] ]
-        if (Array.isArray(source[0])) return { rows: source[0], sortCriteria }
-        return { rows: source, sortCriteria }
-      }
-
-      // PARA map 형태: { PARA1: [..], PARA2: [..], ... } (+ metadata keys)
-      if (source && typeof source === 'object') {
-        const keys = Object.keys(source)
-        const merged = []
-        keys.forEach((key) => {
-          const value = source[key]
-          if (Array.isArray(value)) {
-            value.forEach((row) => {
-              merged.push({ ...(row || {}), PARA: key })
-            })
-          }
-        })
-        return { rows: merged, sortCriteria }
-      }
-
-      return { rows: [], sortCriteria }
-    }
-
-    const sortCriteria = computed(() => {
-      const payload = extractPayload(props.data)
-      const raw = payload.sortCriteria
-      if (typeof raw !== 'string') return 'TIMELY'
-      const upper = raw.toUpperCase()
-      return VALID_SORT_CRITERIA.includes(upper) ? upper : 'TIMELY'
-    })
-
-    const coerceNumber = (value) => {
-      if (value === null || value === undefined) return null
-      if (typeof value === 'number') return Number.isFinite(value) ? value : null
-      const parsed = Number(value)
-      return Number.isFinite(parsed) ? parsed : null
-    }
-
-    const compareMaybeNumeric = (a, b) => {
-      const aNum = coerceNumber(a)
-      const bNum = coerceNumber(b)
-      if (aNum !== null && bNum !== null) return aNum - bNum
-      // 날짜/문자열 정렬은 localeCompare로 안정적으로 처리
-      return String(a ?? '').localeCompare(String(b ?? ''), undefined, { numeric: true, sensitivity: 'base' })
-    }
-
-    const uniqueInOrder = (arr) => {
-      const seen = new Set()
-      const out = []
-      arr.forEach((v) => {
-        const key = v === null || v === undefined ? '__missing__' : String(v)
-        if (!seen.has(key)) {
-          seen.add(key)
-          out.push(v)
-        }
-      })
-      return out
-    }
-
-    // 색상 팔레트 (DEVICE/TEST_EQ 등 공통 사용)
-    const getGroupColor = (groupName, alpha = 1) => {
-      const palette = [
-        [102, 126, 234],
-        [118, 75, 162],
-        [255, 128, 10],
-        [46, 204, 113],
-        [231, 76, 60],
-        [52, 152, 219],
-        [155, 89, 182],
-        [241, 196, 15],
-        [230, 126, 34],
-        [26, 188, 156],
-        [192, 57, 43],
-        [142, 68, 173],
-        [39, 174, 96],
-        [211, 84, 0],
-        [41, 128, 185],
-        [243, 156, 18],
-        [149, 165, 166],
-        [44, 62, 80],
-        [127, 140, 141],
-        [189, 195, 199]
-      ]
-
-      const name = groupName === null || groupName === undefined ? 'Series' : String(groupName)
-      let hash = 0
-      for (let i = 0; i < name.length; i++) {
-        const char = name.charCodeAt(i)
-        hash = ((hash << 5) - hash) + char
-        hash &= hash
-      }
-      const idx = Math.abs(hash) % palette.length
-      const [r, g, b] = palette[idx]
-      return `rgba(${r}, ${g}, ${b}, ${alpha})`
-    }
-
-    // (MIN/Q1/Q2/Q3/MAX) 요약값만 있을 때 박스 데이터 생성
-    const generateBoxPlotDataFromSummary = (min, q1, q2, q3, max, count = 30) => {
-      const minVal = coerceNumber(min)
-      const q1Val = coerceNumber(q1)
-      const q2Val = coerceNumber(q2)
-      const q3Val = coerceNumber(q3)
-      const maxVal = coerceNumber(max)
-      if ([minVal, q1Val, q2Val, q3Val, maxVal].some(v => v === null)) return []
-
-      const data = []
-      const q1Count = Math.floor(count * 0.25)
-      const q2Count = Math.floor(count * 0.25)
-      const q3Count = Math.floor(count * 0.25)
-      const q4Count = count - q1Count - q2Count - q3Count
-
-      for (let i = 0; i < q1Count; i++) data.push(minVal + Math.random() * (q1Val - minVal))
-      for (let i = 0; i < q2Count; i++) data.push(q1Val + Math.random() * (q2Val - q1Val))
-      for (let i = 0; i < q3Count; i++) data.push(q2Val + Math.random() * (q3Val - q2Val))
-      for (let i = 0; i < q4Count; i++) data.push(q3Val + Math.random() * (maxVal - q3Val))
-
-      return data
-    }
-
     // 실제 데이터 추출 함수 (PARA별 객체 구조 처리)
     const getRealData = () => {
       console.log('PCMTrendPointChart - props.data 확인:', props.data)
@@ -266,12 +112,84 @@ export default defineComponent({
         return []
       }
 
-      const payload = extractPayload(props.data)
-      const rows = payload.rows || []
-      console.log('PCMTrendPointChart - extractPayload rows:', rows.length, 'sort_criteria:', payload.sortCriteria)
-      if (!rows.length) return []
-      console.log('PCMTrendPointChart - rows sample:', rows[0])
-      return rows
+      // PARA별 객체 구조인지 확인 (PARA1, PARA2, ... 형태)
+      if (typeof props.data === 'object' && !Array.isArray(props.data)) {
+        const keys = Object.keys(props.data)
+        console.log('PCMTrendPointChart - 객체 구조 감지, 키들:', keys)
+        
+        // PARA로 시작하는 키들이 있는지 확인하거나, 첫 번째 값이 배열인지 확인
+        const firstKey = keys[0]
+        if (firstKey && Array.isArray(props.data[firstKey])) {
+          console.log('PCMTrendPointChart - PARA별 객체 구조 확인됨')
+          
+          // 모든 PARA 데이터를 하나의 배열로 합치기
+          const allData = []
+          keys.forEach(paraKey => {
+            const paraData = props.data[paraKey]
+            if (Array.isArray(paraData)) {
+              console.log(`PCMTrendPointChart - ${paraKey}: ${paraData.length}개 데이터`)
+              console.log(`PCMTrendPointChart - ${paraKey} 첫 번째 데이터:`, paraData[0])
+              
+              // 각 데이터에 PARA 정보 추가
+              paraData.forEach(row => {
+                allData.push({
+                  ...row,
+                  PARA: paraKey
+                })
+              })
+            }
+          })
+          console.log('PCMTrendPointChart - 전체 병합된 데이터:', allData.length, '개')
+          console.log('PCMTrendPointChart - 병합된 데이터 샘플:', allData[0])
+          return allData
+        }
+      }
+
+      // real_data 구조인지 확인 (중첩된 경우)
+      if (props.data.real_data && typeof props.data.real_data === 'object') {
+        console.log('PCMTrendPointChart - real_data 중첩 구조 감지:', Object.keys(props.data.real_data))
+        // real_data 안의 모든 PARA 데이터를 하나의 배열로 합치기
+        const allData = []
+        Object.keys(props.data.real_data).forEach(paraKey => {
+          const paraData = props.data.real_data[paraKey]
+          if (Array.isArray(paraData)) {
+            // 각 데이터에 PARA 정보 추가
+            paraData.forEach(row => {
+              allData.push({
+                ...row,
+                PARA: paraKey
+              })
+            })
+          }
+        })
+        console.log('PCMTrendPointChart - real_data에서 추출한 전체 데이터:', allData.length, '개')
+        return allData
+      }
+
+      // 기존 구조 처리 (배열)
+      if (Array.isArray(props.data)) {
+        console.log('PCMTrendPointChart - 배열 구조 감지')
+        if (props.data.length === 0) {
+          console.log('PCMTrendPointChart - props.data가 빈 배열')
+          return []
+        }
+        
+        // props.data[0]이 배열인 경우 (기존 방식)
+        const data = props.data[0]
+        if (Array.isArray(data)) {
+          console.log('PCMTrendPointChart - props.data[0] 배열 구조 사용')
+          return data
+        }
+        
+        // props.data 자체가 데이터 배열인 경우
+        if (props.data[0] && props.data[0].DATE_WAFER_ID !== undefined) {
+          console.log('PCMTrendPointChart - props.data 직접 사용')
+          return props.data
+        }
+      }
+      
+      console.log('PCMTrendPointChart - 알 수 없는 데이터 구조')
+      return []
     }
 
     // real_data 존재 여부 확인
@@ -308,7 +226,7 @@ export default defineComponent({
       }
     }
 
-    // 원본 createChart 함수 기반으로 수정 (box + spec lines + sort_criteria)
+    // 원본 createChart 함수 기반으로 수정
     const createSingleChart = (container, inputData, chartTitle = null) => {
       if (!container) return
       
@@ -320,161 +238,31 @@ export default defineComponent({
       }
 
       console.log(`PCMTrendPointChart 차트 생성: ${chartTitle || 'Default'} - ${data.length}개 데이터`)
-
-      const currentSort = sortCriteria.value
-      const colorField = currentSort === 'TEST_EQ' ? 'TEST_EQ' : 'DEVICE' // TIMELY/DEVICE => DEVICE, TEST_EQ => TEST_EQ
-
-      // 파이썬 로직과 동일하게 정렬 기준 반영
-      const sorted = [...data].sort((a, b) => {
-        if (currentSort === 'DEVICE' || currentSort === 'TEST_EQ') {
-          const aKey = a?.[currentSort]
-          const bKey = b?.[currentSort]
-          const cmpKey = String(aKey ?? '').localeCompare(String(bKey ?? ''), undefined, { numeric: true, sensitivity: 'base' })
-          if (cmpKey !== 0) return cmpKey
-        }
-        return compareMaybeNumeric(a?.DATE_WAFER_ID, b?.DATE_WAFER_ID)
+      
+      // PCM_SITE별로 그룹화
+      const siteGroups = {}
+      data.forEach(row => {
+        if (!siteGroups[row.PCM_SITE]) siteGroups[row.PCM_SITE] = { x: [], y: [] }
+        siteGroups[row.PCM_SITE].x.push(row.DATE_WAFER_ID)
+        siteGroups[row.PCM_SITE].y.push(row.VALUE)
       })
-
-      // x축 카테고리 순서(출현 순서 유지) - Plotly/px.box의 category_orders 효과
-      const categoryOrder = uniqueInOrder(sorted.map((row) => row?.DATE_WAFER_ID))
-
-      // tick label 샘플링
-      const maxLabels = props.maxLabels || 50
-      const step = Math.max(1, Math.floor(categoryOrder.length / maxLabels))
-      const sampledLabels = categoryOrder.filter((_, index) => index % step === 0)
-
-      // 그룹 필드가 없으면 안전하게 fallback
-      const resolvedGroupField = (sorted.length && sorted[0] && sorted[0][colorField] !== undefined)
-        ? colorField
-        : (sorted.length && sorted[0] && sorted[0].DEVICE !== undefined)
-          ? 'DEVICE'
-          : (sorted.length && sorted[0] && sorted[0].PCM_SITE !== undefined)
-            ? 'PCM_SITE'
-            : null
-
-      const groupKeys = uniqueInOrder(sorted.map((row) => resolvedGroupField ? row?.[resolvedGroupField] : 'Series'))
-
-      const hasSummary = sorted.some((row) =>
-        row && row.MIN !== undefined && row.MAX !== undefined && row.Q1 !== undefined && row.Q2 !== undefined && row.Q3 !== undefined
-      )
-      const hasValue = sorted.some((row) => row && row.VALUE !== undefined)
-
-      // Box traces (overlay)
-      const boxTraces = groupKeys.map((groupKey) => {
-        const rows = sorted.filter((row) => {
-          if (!resolvedGroupField) return true
-          return row?.[resolvedGroupField] === groupKey
-        })
-
-        const x = []
-        const y = []
-
-        if (hasSummary) {
-          rows.forEach((row) => {
-            const values = generateBoxPlotDataFromSummary(row.MIN, row.Q1, row.Q2, row.Q3, row.MAX)
-            if (!values.length) return
-            values.forEach((val) => {
-              x.push(row.DATE_WAFER_ID)
-              y.push(val)
-            })
-          })
-        } else if (hasValue) {
-          rows.forEach((row) => {
-            const val = coerceNumber(row.VALUE)
-            if (val === null) return
-            x.push(row.DATE_WAFER_ID)
-            y.push(val)
-          })
-        }
-
-        const traceName = resolvedGroupField ? `${resolvedGroupField}: ${groupKey}` : String(groupKey ?? 'Series')
-        const baseColor = getGroupColor(groupKey)
-        return {
-          type: 'box',
-          name: traceName,
-          x,
-          y,
-          boxpoints: 'outliers',
-          marker: { color: baseColor, size: 4 },
-          line: { color: baseColor, width: 2 },
-          fillcolor: getGroupColor(groupKey, 0.35),
-          showlegend: true
-        }
-      }).filter((t) => Array.isArray(t.y) && t.y.length > 0)
-
-      // Spec/control lines (가능한 경우에만)
-      const firstRowByDate = new Map()
-      sorted.forEach((row) => {
-        const key = row?.DATE_WAFER_ID
-        if (!firstRowByDate.has(key)) firstRowByDate.set(key, row)
-      })
-      const seriesByDate = (field) => categoryOrder.map((date) => coerceNumber(firstRowByDate.get(date)?.[field]))
-      const shouldDrawLine = (arr) => arr.some((v) => typeof v === 'number' && Number.isFinite(v))
-
-      const usl = seriesByDate('USL')
-      const tgt = seriesByDate('TGT')
-      const lsl = seriesByDate('LSL')
-      const ucl = seriesByDate('UCL')
-      const lcl = seriesByDate('LCL')
-
-      const lineTraces = []
-      if (shouldDrawLine(usl)) {
-        lineTraces.push({
-          type: 'scatter',
-          mode: 'lines',
-          name: 'USL',
-          x: categoryOrder,
-          y: usl,
-          line: { color: 'rgba(255, 0, 0, 0.8)', width: 2 },
-          showlegend: true
-        })
-      }
-      if (shouldDrawLine(tgt)) {
-        lineTraces.push({
-          type: 'scatter',
-          mode: 'lines',
-          name: 'TGT',
-          x: categoryOrder,
-          y: tgt,
-          line: { color: 'rgba(0, 0, 0, 0.5)', width: 2 },
-          showlegend: true
-        })
-      }
-      if (shouldDrawLine(lsl)) {
-        lineTraces.push({
-          type: 'scatter',
-          mode: 'lines',
-          name: 'LSL',
-          x: categoryOrder,
-          y: lsl,
-          line: { color: 'rgba(255, 0, 0, 0.8)', width: 2 },
-          showlegend: true
-        })
-      }
-      if (shouldDrawLine(ucl)) {
-        lineTraces.push({
-          type: 'scatter',
-          mode: 'lines',
-          name: 'UCL',
-          x: categoryOrder,
-          y: ucl,
-          line: { color: 'rgba(255, 128, 10, 0.5)', width: 2, dash: 'dash' },
-          showlegend: true
-        })
-      }
-      if (shouldDrawLine(lcl)) {
-        lineTraces.push({
-          type: 'scatter',
-          mode: 'lines',
-          name: 'LCL',
-          x: categoryOrder,
-          y: lcl,
-          line: { color: 'rgba(255, 128, 10, 0.5)', width: 2, dash: 'dash' },
-          showlegend: true
-        })
-      }
-
-      const traces = [...boxTraces, ...lineTraces]
+      
+      // 각 site별 trace 생성
+      const traces = Object.keys(siteGroups).map(site => ({
+        type: 'scatter',
+        mode: 'lines+markers',
+        x: siteGroups[site].x,
+        y: siteGroups[site].y,
+        name: `Site ${site}`,
+        marker: { size: 6 },
+        line: { width: 1.5 }
+      }))
+      
+      // x축 라벨 생성 (적절한 간격으로 표시)
+      const xOrder = [...new Set(data.map(row => row.DATE_WAFER_ID))].sort((a, b) => a - b)
+      const maxLabels = 50
+      const step = Math.max(1, Math.floor(xOrder.length / maxLabels))
+      const sampledLabels = xOrder.filter((_, index) => index % step === 0)
       
       const layout = {
         title: {
@@ -502,7 +290,7 @@ export default defineComponent({
           side: 'bottom',
           tickposition: 'outside',
           categoryorder: 'array',
-          categoryarray: categoryOrder
+          categoryarray: xOrder
         },
         yaxis: {
           title: 'Value',
@@ -510,7 +298,6 @@ export default defineComponent({
           gridcolor: '#f0f0f0'
         },
         height: props.height,
-        boxmode: 'overlay',
         showlegend: true,
         legend: {
           orientation: 'v',
@@ -537,8 +324,7 @@ export default defineComponent({
         container: container,
         tracesCount: traces.length,
         dataLength: data.length,
-        sort_criteria: currentSort,
-        color_field: colorField
+        siteGroups: Object.keys(siteGroups)
       })
       
       Plotly.newPlot(container, traces, layout, {

--- a/src/components/PCMTrendPointChart.vue
+++ b/src/components/PCMTrendPointChart.vue
@@ -100,6 +100,160 @@ export default defineComponent({
     const chartContainer = ref(null)
     const chartRefs = ref([])
 
+    const VALID_SORT_CRITERIA = ['TIMELY', 'DEVICE', 'TEST_EQ']
+
+    /**
+     * backend payload가 아래처럼 바뀌어도 견고하게 처리:
+     * - Array rows
+     * - { real_data: <rows|para-map>, sort_criteria: '...' }
+     * - { PARA1: [...], PARA2: [...], sort_criteria: '...' }
+     * - { real_data: { PARA1: [...], ... }, sort_criteria: '...' }
+     */
+    const extractPayload = (input) => {
+      let sortCriteria = null
+      let source = input
+
+      if (!source) return { rows: [], sortCriteria }
+
+      // wrapper: { real_data, sort_criteria }
+      if (typeof source === 'object' && !Array.isArray(source)) {
+        if (source.sort_criteria) sortCriteria = source.sort_criteria
+        if (source.sortCriteria) sortCriteria = source.sortCriteria
+
+        if (source.real_data !== undefined) {
+          source = source.real_data
+        }
+      }
+
+      // wrapper: { real_data: { ... } } 형태가 한 번 더 중첩될 수 있음
+      if (source && typeof source === 'object' && !Array.isArray(source) && source.real_data !== undefined) {
+        if (!sortCriteria && source.sort_criteria) sortCriteria = source.sort_criteria
+        if (!sortCriteria && source.sortCriteria) sortCriteria = source.sortCriteria
+        source = source.real_data
+      }
+
+      // Array 형태
+      if (Array.isArray(source)) {
+        if (source.length === 0) return { rows: [], sortCriteria }
+        // legacy: [ [rows] ]
+        if (Array.isArray(source[0])) return { rows: source[0], sortCriteria }
+        return { rows: source, sortCriteria }
+      }
+
+      // PARA map 형태: { PARA1: [..], PARA2: [..], ... } (+ metadata keys)
+      if (source && typeof source === 'object') {
+        const keys = Object.keys(source)
+        const merged = []
+        keys.forEach((key) => {
+          const value = source[key]
+          if (Array.isArray(value)) {
+            value.forEach((row) => {
+              merged.push({ ...(row || {}), PARA: key })
+            })
+          }
+        })
+        return { rows: merged, sortCriteria }
+      }
+
+      return { rows: [], sortCriteria }
+    }
+
+    const sortCriteria = computed(() => {
+      const payload = extractPayload(props.data)
+      const raw = payload.sortCriteria
+      if (typeof raw !== 'string') return 'TIMELY'
+      const upper = raw.toUpperCase()
+      return VALID_SORT_CRITERIA.includes(upper) ? upper : 'TIMELY'
+    })
+
+    const coerceNumber = (value) => {
+      if (value === null || value === undefined) return null
+      if (typeof value === 'number') return Number.isFinite(value) ? value : null
+      const parsed = Number(value)
+      return Number.isFinite(parsed) ? parsed : null
+    }
+
+    const compareMaybeNumeric = (a, b) => {
+      const aNum = coerceNumber(a)
+      const bNum = coerceNumber(b)
+      if (aNum !== null && bNum !== null) return aNum - bNum
+      // 날짜/문자열 정렬은 localeCompare로 안정적으로 처리
+      return String(a ?? '').localeCompare(String(b ?? ''), undefined, { numeric: true, sensitivity: 'base' })
+    }
+
+    const uniqueInOrder = (arr) => {
+      const seen = new Set()
+      const out = []
+      arr.forEach((v) => {
+        const key = v === null || v === undefined ? '__missing__' : String(v)
+        if (!seen.has(key)) {
+          seen.add(key)
+          out.push(v)
+        }
+      })
+      return out
+    }
+
+    // 색상 팔레트 (DEVICE/TEST_EQ 등 공통 사용)
+    const getGroupColor = (groupName, alpha = 1) => {
+      const palette = [
+        [102, 126, 234],
+        [118, 75, 162],
+        [255, 128, 10],
+        [46, 204, 113],
+        [231, 76, 60],
+        [52, 152, 219],
+        [155, 89, 182],
+        [241, 196, 15],
+        [230, 126, 34],
+        [26, 188, 156],
+        [192, 57, 43],
+        [142, 68, 173],
+        [39, 174, 96],
+        [211, 84, 0],
+        [41, 128, 185],
+        [243, 156, 18],
+        [149, 165, 166],
+        [44, 62, 80],
+        [127, 140, 141],
+        [189, 195, 199]
+      ]
+
+      const name = groupName === null || groupName === undefined ? 'Series' : String(groupName)
+      let hash = 0
+      for (let i = 0; i < name.length; i++) {
+        const char = name.charCodeAt(i)
+        hash = ((hash << 5) - hash) + char
+        hash &= hash
+      }
+      const idx = Math.abs(hash) % palette.length
+      const [r, g, b] = palette[idx]
+      return `rgba(${r}, ${g}, ${b}, ${alpha})`
+    }
+
+    // (MIN/Q1/Q2/Q3/MAX) 요약값만 있을 때 박스 데이터 생성
+    const generateBoxPlotDataFromSummary = (min, q1, q2, q3, max, count = 30) => {
+      const minVal = coerceNumber(min)
+      const q1Val = coerceNumber(q1)
+      const q2Val = coerceNumber(q2)
+      const q3Val = coerceNumber(q3)
+      const maxVal = coerceNumber(max)
+      if ([minVal, q1Val, q2Val, q3Val, maxVal].some(v => v === null)) return []
+
+      const data = []
+      const q1Count = Math.floor(count * 0.25)
+      const q2Count = Math.floor(count * 0.25)
+      const q3Count = Math.floor(count * 0.25)
+      const q4Count = count - q1Count - q2Count - q3Count
+
+      for (let i = 0; i < q1Count; i++) data.push(minVal + Math.random() * (q1Val - minVal))
+      for (let i = 0; i < q2Count; i++) data.push(q1Val + Math.random() * (q2Val - q1Val))
+      for (let i = 0; i < q3Count; i++) data.push(q2Val + Math.random() * (q3Val - q2Val))
+      for (let i = 0; i < q4Count; i++) data.push(q3Val + Math.random() * (maxVal - q3Val))
+
+      return data
+    }
+
     // 실제 데이터 추출 함수 (PARA별 객체 구조 처리)
     const getRealData = () => {
       console.log('PCMTrendPointChart - props.data 확인:', props.data)
@@ -112,84 +266,12 @@ export default defineComponent({
         return []
       }
 
-      // PARA별 객체 구조인지 확인 (PARA1, PARA2, ... 형태)
-      if (typeof props.data === 'object' && !Array.isArray(props.data)) {
-        const keys = Object.keys(props.data)
-        console.log('PCMTrendPointChart - 객체 구조 감지, 키들:', keys)
-        
-        // PARA로 시작하는 키들이 있는지 확인하거나, 첫 번째 값이 배열인지 확인
-        const firstKey = keys[0]
-        if (firstKey && Array.isArray(props.data[firstKey])) {
-          console.log('PCMTrendPointChart - PARA별 객체 구조 확인됨')
-          
-          // 모든 PARA 데이터를 하나의 배열로 합치기
-          const allData = []
-          keys.forEach(paraKey => {
-            const paraData = props.data[paraKey]
-            if (Array.isArray(paraData)) {
-              console.log(`PCMTrendPointChart - ${paraKey}: ${paraData.length}개 데이터`)
-              console.log(`PCMTrendPointChart - ${paraKey} 첫 번째 데이터:`, paraData[0])
-              
-              // 각 데이터에 PARA 정보 추가
-              paraData.forEach(row => {
-                allData.push({
-                  ...row,
-                  PARA: paraKey
-                })
-              })
-            }
-          })
-          console.log('PCMTrendPointChart - 전체 병합된 데이터:', allData.length, '개')
-          console.log('PCMTrendPointChart - 병합된 데이터 샘플:', allData[0])
-          return allData
-        }
-      }
-
-      // real_data 구조인지 확인 (중첩된 경우)
-      if (props.data.real_data && typeof props.data.real_data === 'object') {
-        console.log('PCMTrendPointChart - real_data 중첩 구조 감지:', Object.keys(props.data.real_data))
-        // real_data 안의 모든 PARA 데이터를 하나의 배열로 합치기
-        const allData = []
-        Object.keys(props.data.real_data).forEach(paraKey => {
-          const paraData = props.data.real_data[paraKey]
-          if (Array.isArray(paraData)) {
-            // 각 데이터에 PARA 정보 추가
-            paraData.forEach(row => {
-              allData.push({
-                ...row,
-                PARA: paraKey
-              })
-            })
-          }
-        })
-        console.log('PCMTrendPointChart - real_data에서 추출한 전체 데이터:', allData.length, '개')
-        return allData
-      }
-
-      // 기존 구조 처리 (배열)
-      if (Array.isArray(props.data)) {
-        console.log('PCMTrendPointChart - 배열 구조 감지')
-        if (props.data.length === 0) {
-          console.log('PCMTrendPointChart - props.data가 빈 배열')
-          return []
-        }
-        
-        // props.data[0]이 배열인 경우 (기존 방식)
-        const data = props.data[0]
-        if (Array.isArray(data)) {
-          console.log('PCMTrendPointChart - props.data[0] 배열 구조 사용')
-          return data
-        }
-        
-        // props.data 자체가 데이터 배열인 경우
-        if (props.data[0] && props.data[0].DATE_WAFER_ID !== undefined) {
-          console.log('PCMTrendPointChart - props.data 직접 사용')
-          return props.data
-        }
-      }
-      
-      console.log('PCMTrendPointChart - 알 수 없는 데이터 구조')
-      return []
+      const payload = extractPayload(props.data)
+      const rows = payload.rows || []
+      console.log('PCMTrendPointChart - extractPayload rows:', rows.length, 'sort_criteria:', payload.sortCriteria)
+      if (!rows.length) return []
+      console.log('PCMTrendPointChart - rows sample:', rows[0])
+      return rows
     }
 
     // real_data 존재 여부 확인
@@ -226,7 +308,7 @@ export default defineComponent({
       }
     }
 
-    // 원본 createChart 함수 기반으로 수정
+    // 원본 createChart 함수 기반으로 수정 (box + spec lines + sort_criteria)
     const createSingleChart = (container, inputData, chartTitle = null) => {
       if (!container) return
       
@@ -238,31 +320,161 @@ export default defineComponent({
       }
 
       console.log(`PCMTrendPointChart 차트 생성: ${chartTitle || 'Default'} - ${data.length}개 데이터`)
-      
-      // PCM_SITE별로 그룹화
-      const siteGroups = {}
-      data.forEach(row => {
-        if (!siteGroups[row.PCM_SITE]) siteGroups[row.PCM_SITE] = { x: [], y: [] }
-        siteGroups[row.PCM_SITE].x.push(row.DATE_WAFER_ID)
-        siteGroups[row.PCM_SITE].y.push(row.VALUE)
+
+      const currentSort = sortCriteria.value
+      const colorField = currentSort === 'TEST_EQ' ? 'TEST_EQ' : 'DEVICE' // TIMELY/DEVICE => DEVICE, TEST_EQ => TEST_EQ
+
+      // 파이썬 로직과 동일하게 정렬 기준 반영
+      const sorted = [...data].sort((a, b) => {
+        if (currentSort === 'DEVICE' || currentSort === 'TEST_EQ') {
+          const aKey = a?.[currentSort]
+          const bKey = b?.[currentSort]
+          const cmpKey = String(aKey ?? '').localeCompare(String(bKey ?? ''), undefined, { numeric: true, sensitivity: 'base' })
+          if (cmpKey !== 0) return cmpKey
+        }
+        return compareMaybeNumeric(a?.DATE_WAFER_ID, b?.DATE_WAFER_ID)
       })
-      
-      // 각 site별 trace 생성
-      const traces = Object.keys(siteGroups).map(site => ({
-        type: 'scatter',
-        mode: 'lines+markers',
-        x: siteGroups[site].x,
-        y: siteGroups[site].y,
-        name: `Site ${site}`,
-        marker: { size: 6 },
-        line: { width: 1.5 }
-      }))
-      
-      // x축 라벨 생성 (적절한 간격으로 표시)
-      const xOrder = [...new Set(data.map(row => row.DATE_WAFER_ID))].sort((a, b) => a - b)
-      const maxLabels = 50
-      const step = Math.max(1, Math.floor(xOrder.length / maxLabels))
-      const sampledLabels = xOrder.filter((_, index) => index % step === 0)
+
+      // x축 카테고리 순서(출현 순서 유지) - Plotly/px.box의 category_orders 효과
+      const categoryOrder = uniqueInOrder(sorted.map((row) => row?.DATE_WAFER_ID))
+
+      // tick label 샘플링
+      const maxLabels = props.maxLabels || 50
+      const step = Math.max(1, Math.floor(categoryOrder.length / maxLabels))
+      const sampledLabels = categoryOrder.filter((_, index) => index % step === 0)
+
+      // 그룹 필드가 없으면 안전하게 fallback
+      const resolvedGroupField = (sorted.length && sorted[0] && sorted[0][colorField] !== undefined)
+        ? colorField
+        : (sorted.length && sorted[0] && sorted[0].DEVICE !== undefined)
+          ? 'DEVICE'
+          : (sorted.length && sorted[0] && sorted[0].PCM_SITE !== undefined)
+            ? 'PCM_SITE'
+            : null
+
+      const groupKeys = uniqueInOrder(sorted.map((row) => resolvedGroupField ? row?.[resolvedGroupField] : 'Series'))
+
+      const hasSummary = sorted.some((row) =>
+        row && row.MIN !== undefined && row.MAX !== undefined && row.Q1 !== undefined && row.Q2 !== undefined && row.Q3 !== undefined
+      )
+      const hasValue = sorted.some((row) => row && row.VALUE !== undefined)
+
+      // Box traces (overlay)
+      const boxTraces = groupKeys.map((groupKey) => {
+        const rows = sorted.filter((row) => {
+          if (!resolvedGroupField) return true
+          return row?.[resolvedGroupField] === groupKey
+        })
+
+        const x = []
+        const y = []
+
+        if (hasSummary) {
+          rows.forEach((row) => {
+            const values = generateBoxPlotDataFromSummary(row.MIN, row.Q1, row.Q2, row.Q3, row.MAX)
+            if (!values.length) return
+            values.forEach((val) => {
+              x.push(row.DATE_WAFER_ID)
+              y.push(val)
+            })
+          })
+        } else if (hasValue) {
+          rows.forEach((row) => {
+            const val = coerceNumber(row.VALUE)
+            if (val === null) return
+            x.push(row.DATE_WAFER_ID)
+            y.push(val)
+          })
+        }
+
+        const traceName = resolvedGroupField ? `${resolvedGroupField}: ${groupKey}` : String(groupKey ?? 'Series')
+        const baseColor = getGroupColor(groupKey)
+        return {
+          type: 'box',
+          name: traceName,
+          x,
+          y,
+          boxpoints: 'outliers',
+          marker: { color: baseColor, size: 4 },
+          line: { color: baseColor, width: 2 },
+          fillcolor: getGroupColor(groupKey, 0.35),
+          showlegend: true
+        }
+      }).filter((t) => Array.isArray(t.y) && t.y.length > 0)
+
+      // Spec/control lines (가능한 경우에만)
+      const firstRowByDate = new Map()
+      sorted.forEach((row) => {
+        const key = row?.DATE_WAFER_ID
+        if (!firstRowByDate.has(key)) firstRowByDate.set(key, row)
+      })
+      const seriesByDate = (field) => categoryOrder.map((date) => coerceNumber(firstRowByDate.get(date)?.[field]))
+      const shouldDrawLine = (arr) => arr.some((v) => typeof v === 'number' && Number.isFinite(v))
+
+      const usl = seriesByDate('USL')
+      const tgt = seriesByDate('TGT')
+      const lsl = seriesByDate('LSL')
+      const ucl = seriesByDate('UCL')
+      const lcl = seriesByDate('LCL')
+
+      const lineTraces = []
+      if (shouldDrawLine(usl)) {
+        lineTraces.push({
+          type: 'scatter',
+          mode: 'lines',
+          name: 'USL',
+          x: categoryOrder,
+          y: usl,
+          line: { color: 'rgba(255, 0, 0, 0.8)', width: 2 },
+          showlegend: true
+        })
+      }
+      if (shouldDrawLine(tgt)) {
+        lineTraces.push({
+          type: 'scatter',
+          mode: 'lines',
+          name: 'TGT',
+          x: categoryOrder,
+          y: tgt,
+          line: { color: 'rgba(0, 0, 0, 0.5)', width: 2 },
+          showlegend: true
+        })
+      }
+      if (shouldDrawLine(lsl)) {
+        lineTraces.push({
+          type: 'scatter',
+          mode: 'lines',
+          name: 'LSL',
+          x: categoryOrder,
+          y: lsl,
+          line: { color: 'rgba(255, 0, 0, 0.8)', width: 2 },
+          showlegend: true
+        })
+      }
+      if (shouldDrawLine(ucl)) {
+        lineTraces.push({
+          type: 'scatter',
+          mode: 'lines',
+          name: 'UCL',
+          x: categoryOrder,
+          y: ucl,
+          line: { color: 'rgba(255, 128, 10, 0.5)', width: 2, dash: 'dash' },
+          showlegend: true
+        })
+      }
+      if (shouldDrawLine(lcl)) {
+        lineTraces.push({
+          type: 'scatter',
+          mode: 'lines',
+          name: 'LCL',
+          x: categoryOrder,
+          y: lcl,
+          line: { color: 'rgba(255, 128, 10, 0.5)', width: 2, dash: 'dash' },
+          showlegend: true
+        })
+      }
+
+      const traces = [...boxTraces, ...lineTraces]
       
       const layout = {
         title: {
@@ -290,7 +502,7 @@ export default defineComponent({
           side: 'bottom',
           tickposition: 'outside',
           categoryorder: 'array',
-          categoryarray: xOrder
+          categoryarray: categoryOrder
         },
         yaxis: {
           title: 'Value',
@@ -298,6 +510,7 @@ export default defineComponent({
           gridcolor: '#f0f0f0'
         },
         height: props.height,
+        boxmode: 'overlay',
         showlegend: true,
         legend: {
           orientation: 'v',
@@ -324,7 +537,8 @@ export default defineComponent({
         container: container,
         tracesCount: traces.length,
         dataLength: data.length,
-        siteGroups: Object.keys(siteGroups)
+        sort_criteria: currentSort,
+        color_field: colorField
       })
       
       Plotly.newPlot(container, traces, layout, {


### PR DESCRIPTION
Update `PCMTrendPointChart` to render boxplots with dynamic sorting and coloring based on `sort_criteria` from the backend, aligning with the provided Python Plotly logic.

The chart now supports `TIMELY`, `DEVICE`, or `TEST_EQ` sorting criteria, dynamically adjusts box colors, and displays USL/TGT/LSL/UCL/LCL lines. `App.vue` has been updated to pass the new `sort_criteria` parameter to the component.

---
<a href="https://cursor.com/background-agent?bcId=bc-a53d7e39-ba88-4462-86a7-b7f55cf6231e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a53d7e39-ba88-4462-86a7-b7f55cf6231e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add backend-driven sort_criteria support and overhaul PCMTrendChart to normalize inputs, sort/group by TIMELY/DEVICE/TEST_EQ, and improve rendering/metadata.
> 
> - **PCM Trend flow**
>   - **App.vue**: When `result === 'lot_start'`, wrap chart payload as `{ real_data, sort_criteria }` if `sort_criteria` exists (both history and streaming paths), enabling backend-driven sorting in downstream charts.
> - **PCMTrendChart.vue**
>   - **Input normalization**: Accepts `Array|Object` for `props.data`; robust `extractPayload` handles `{ real_data, sort_criteria }`, PARA-mapped objects, and legacy shapes.
>   - **Sorting & grouping**: Supports `TIMELY`, `DEVICE`, `TEST_EQ` via `sort_criteria`; sorts by date or by group+date; colors/grouping by `DEVICE` or `TEST_EQ` with stable palette.
>   - **Rendering**: Generates box traces per group; draws `USL/TGT/LSL/UCL/LCL` lines with safer numeric coercion; improves axis tick sampling and sets `boxmode: 'overlay'`.
>   - **Metadata/UI**: Title includes date range and spec values; single/multi-PARA handling updated; record count uses normalized display data; exposes `getDisplayData()` for templates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d09de32690882d03793e1d81c58f0e39f501dab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->