### PR TITLE
Sameness to trend 그래프 분할

### DIFF
--- a/src/components/PCMToTrend.vue
+++ b/src/components/PCMToTrend.vue
@@ -1,16 +1,16 @@
 <template>
   <div class="pcm-to-trend">
-    <!-- PARA별로 그룹화된 차트들 -->
-    <div v-if="paraTypes.length > 1" class="multi-para-charts">
+    <!-- MAIN_ROUTE_DESC별로 그룹화된 차트들 -->
+    <div v-if="routeTypes.length > 1" class="multi-para-charts">
       <div 
-        v-for="(paraType, index) in paraTypes" 
-        :key="paraType"
+        v-for="(routeDesc, index) in routeTypes" 
+        :key="routeDesc"
         class="para-chart-container"
       >
         <div class="para-chart-header">
-          <h3>{{ resultTypeName }} - PARA: {{ paraType }}</h3>
+          <h3>{{ resultTypeName }} - MAIN_ROUTE_DESC: {{ routeDesc }}</h3>
           <div class="para-chart-info">
-            <span class="data-count">{{ getParaData(paraType).length }} records</span>
+            <span class="data-count">{{ getRouteData(routeDesc).length }} records</span>
           </div>
         </div>
         <div 
@@ -20,12 +20,12 @@
       </div>
     </div>
     
-    <!-- 단일 PARA 또는 PARA 컬럼이 없는 경우 기존 로직 -->
+    <!-- 단일 MAIN_ROUTE_DESC 또는 MAIN_ROUTE_DESC 컬럼이 없는 경우 기존 로직 -->
     <div v-else class="single-chart">
-      <div v-if="paraTypes.length === 1" class="para-chart-header">
-        <h3>{{ resultTypeName }} - PARA: {{ paraTypes[0] }}</h3>
+      <div v-if="routeTypes.length === 1" class="para-chart-header">
+        <h3>{{ resultTypeName }} - MAIN_ROUTE_DESC: {{ routeTypes[0] }}</h3>
         <div class="para-chart-info">
-          <span class="data-count">{{ data.length }} records</span>
+          <span class="data-count">{{ getRouteData(routeTypes[0]).length }} records</span>
         </div>
       </div>
       <div ref="chartContainer" class="chart-container"></div>
@@ -143,45 +143,61 @@ export default defineComponent({
       return typeMap[props.resultType] || props.resultType
     })
 
-    // PARA 타입별로 데이터 그룹화
-    const paraTypes = computed(() => {
-      if (!props.data || props.data.length === 0) {
-        console.log('PCMToTrend - 데이터가 없음')
+    const normalizedData = computed(() => {
+      if (!props.data) {
         return []
       }
-      
-      // 데이터가 배열인지 확인
+
       if (Array.isArray(props.data)) {
-        const types = [...new Set(props.data.map(row => row.PARA).filter(para => para !== undefined && para !== null))]
-        console.log('PCMToTrend - PARA 타입 확인:', types)
-        console.log('PCMToTrend - 전체 데이터 개수:', props.data.length)
-        console.log('PCMToTrend - 첫 번째 데이터 샘플:', props.data[0])
-        
-        // 모든 데이터에 PARA 컬럼이 있는지 확인
-        const hasParaCount = props.data.filter(row => row.PARA !== undefined && row.PARA !== null).length
-        console.log(`PCMToTrend - PARA 컬럼이 있는 데이터: ${hasParaCount}/${props.data.length}`)
-        
-        return types.sort()
-      } else if (typeof props.data === 'object' && props.data !== null) {
-        // 객체 형태로 PARA별로 분리된 데이터인 경우
-        const types = Object.keys(props.data)
-        console.log('PCMToTrend - 객체 형태 PARA 타입 확인:', types)
-        return types.sort()
+        return props.data
       }
-      
+
+      if (typeof props.data === 'object' && props.data !== null) {
+        const combined = []
+        Object.values(props.data).forEach(paraData => {
+          if (Array.isArray(paraData)) {
+            combined.push(...paraData)
+          }
+        })
+        return combined
+      }
+
       return []
     })
 
-    const getParaData = (paraType) => {
-      if (Array.isArray(props.data)) {
-        return props.data.filter(row => row.PARA === paraType)
-      } else if (typeof props.data === 'object' && props.data !== null) {
-        // 객체 형태로 PARA별로 분리된 데이터인 경우
-        const paraData = props.data[paraType] || []
-        console.log(`PCMToTrend: PARA ${paraType} 데이터:`, paraData)
-        return paraData
+    // MAIN_ROUTE_DESC 타입별로 데이터 그룹화
+    const routeTypes = computed(() => {
+      if (!normalizedData.value || normalizedData.value.length === 0) {
+        console.log('PCMToTrend - 데이터가 없음')
+        return []
       }
-      return []
+
+      const types = [
+        ...new Set(
+          normalizedData.value
+            .map(row => row.MAIN_ROUTE_DESC)
+            .filter(route => route !== undefined && route !== null && route !== '')
+        )
+      ]
+      console.log('PCMToTrend - MAIN_ROUTE_DESC 타입 확인:', types)
+      console.log('PCMToTrend - 전체 데이터 개수:', normalizedData.value.length)
+      console.log('PCMToTrend - 첫 번째 데이터 샘플:', normalizedData.value[0])
+
+      const hasRouteCount = normalizedData.value.filter(
+        row => row.MAIN_ROUTE_DESC !== undefined && row.MAIN_ROUTE_DESC !== null && row.MAIN_ROUTE_DESC !== ''
+      ).length
+      console.log(`PCMToTrend - MAIN_ROUTE_DESC 컬럼이 있는 데이터: ${hasRouteCount}/${normalizedData.value.length}`)
+
+      return types.sort()
+    })
+
+    const getRouteData = (routeDesc) => {
+      if (!normalizedData.value || normalizedData.value.length === 0) {
+        return []
+      }
+      const routeData = normalizedData.value.filter(row => row.MAIN_ROUTE_DESC === routeDesc)
+      console.log(`PCMToTrend: MAIN_ROUTE_DESC ${routeDesc} 데이터:`, routeData)
+      return routeData
     }
 
     const setChartRef = (el, index) => {
@@ -523,6 +539,11 @@ export default defineComponent({
         console.log('PCMToTrend: 차트 생성 시작 - 데이터 타입:', typeof props.data)
         console.log('PCMToTrend: 데이터 내용:', props.data)
 
+        if (!normalizedData.value || normalizedData.value.length === 0) {
+          console.log('PCMToTrend: 정규화된 데이터가 없어 차트 생성 중단')
+          return
+        }
+
         // 모든 기존 차트 정리 (더 안전한 방식)
         if (chartContainer.value) {
           try {
@@ -557,45 +578,37 @@ export default defineComponent({
 
         await nextTick()
 
-        if (paraTypes.value.length > 1) {
-          // 여러 PARA 타입이 있는 경우 각각 차트 생성
-          console.log(`PCMToTrend: ${paraTypes.value.length}개의 PARA 타입별 차트 생성`, paraTypes.value)
-          paraTypes.value.forEach((paraType, index) => {
-            const paraData = getParaData(paraType)
-            console.log(`PCMToTrend: PARA ${paraType} 데이터 개수: ${paraData.length}`)
-            
-            if (paraData.length === 0) {
-              console.warn(`PCMToTrend: PARA ${paraType}에 데이터가 없음`)
+        if (routeTypes.value.length > 1) {
+          // 여러 MAIN_ROUTE_DESC 타입이 있는 경우 각각 차트 생성
+          console.log(`PCMToTrend: ${routeTypes.value.length}개의 MAIN_ROUTE_DESC별 차트 생성`, routeTypes.value)
+          routeTypes.value.forEach((routeDesc, index) => {
+            const routeData = getRouteData(routeDesc)
+            console.log(`PCMToTrend: MAIN_ROUTE_DESC ${routeDesc} 데이터 개수: ${routeData.length}`)
+
+            if (routeData.length === 0) {
+              console.warn(`PCMToTrend: MAIN_ROUTE_DESC ${routeDesc}에 데이터가 없음`)
               return
             }
             
             const container = chartRefs.value[index]
             if (container) {
-              createSingleChart(container, paraData, `${resultTypeName.value} - PARA: ${paraType}`)
+              createSingleChart(container, routeData, `${resultTypeName.value} - MAIN_ROUTE_DESC: ${routeDesc}`)
             } else {
-              console.warn(`PCMToTrend: PARA ${paraType}의 차트 컨테이너를 찾을 수 없음`)
+              console.warn(`PCMToTrend: MAIN_ROUTE_DESC ${routeDesc}의 차트 컨테이너를 찾을 수 없음`)
             }
           })
         } else {
-          // 단일 PARA 또는 PARA 컬럼이 없는 경우
-          console.log('PCMToTrend: 단일 차트 생성, PARA 타입:', paraTypes.value)
+          // 단일 MAIN_ROUTE_DESC 또는 MAIN_ROUTE_DESC 컬럼이 없는 경우
+          console.log('PCMToTrend: 단일 차트 생성, MAIN_ROUTE_DESC 타입:', routeTypes.value)
           if (chartContainer.value) {
             let dataToUse
-            if (Array.isArray(props.data)) {
-              dataToUse = props.data
-            } else if (typeof props.data === 'object' && props.data !== null) {
-              // 객체 형태인 경우 첫 번째 PARA 데이터 사용
-              const firstParaType = paraTypes.value[0]
-              if (firstParaType) {
-                dataToUse = props.data[firstParaType] || []
-                console.log(`PCMToTrend: 첫 번째 PARA 타입 ${firstParaType}의 데이터 사용:`, dataToUse.length)
-              } else {
-                dataToUse = []
-                console.warn('PCMToTrend: PARA 타입을 찾을 수 없음')
-              }
+            if (routeTypes.value.length === 1) {
+              const firstRoute = routeTypes.value[0]
+              dataToUse = getRouteData(firstRoute)
+              console.log(`PCMToTrend: MAIN_ROUTE_DESC ${firstRoute}의 데이터 사용:`, dataToUse.length)
             } else {
-              dataToUse = []
-              console.warn('PCMToTrend: 지원되지 않는 데이터 타입:', typeof props.data)
+              dataToUse = normalizedData.value
+              console.log('PCMToTrend: 전체 데이터 사용:', dataToUse.length)
             }
             
             if (dataToUse.length > 0) {
@@ -670,7 +683,7 @@ export default defineComponent({
 
     onMounted(() => {
       console.log('PCMToTrend 마운트됨 - 기본 데이터:', props.data)
-      console.log('PCMToTrend 마운트됨 - PARA 타입들:', paraTypes.value)
+      console.log('PCMToTrend 마운트됨 - MAIN_ROUTE_DESC 타입들:', routeTypes.value)
       createCharts()
     })
 
@@ -683,9 +696,10 @@ export default defineComponent({
     return {
       chartContainer,
       chartRefs,
-      paraTypes,
+      normalizedData,
+      routeTypes,
       resultTypeName,
-      getParaData,
+      getRouteData,
       setChartRef
     }
   }

--- a/src/components/PCMToTrend.vue
+++ b/src/components/PCMToTrend.vue
@@ -143,6 +143,14 @@ export default defineComponent({
       return typeMap[props.resultType] || props.resultType
     })
 
+    const normalizeKey = (value) => {
+      return value
+        .toString()
+        .trim()
+        .toUpperCase()
+        .replace(/[^A-Z0-9]/g, '')
+    }
+
     const findKeyValue = (row, targetKey) => {
       if (!row || typeof row !== 'object') {
         return undefined
@@ -150,12 +158,19 @@ export default defineComponent({
       if (row[targetKey] !== undefined) {
         return row[targetKey]
       }
-      const normalizedTarget = targetKey.trim().toUpperCase()
-      const matchedKey = Object.keys(row).find(
-        key => key.trim().toUpperCase() === normalizedTarget
-      )
-      if (matchedKey) {
-        return row[matchedKey]
+      const normalizedTarget = normalizeKey(targetKey)
+      const keys = Object.keys(row)
+      const exactMatch = keys.find(key => normalizeKey(key) === normalizedTarget)
+      if (exactMatch) {
+        return row[exactMatch]
+      }
+      const startsWithMatch = keys.find(key => normalizeKey(key).startsWith(normalizedTarget))
+      if (startsWithMatch) {
+        return row[startsWithMatch]
+      }
+      const containsMatch = keys.find(key => normalizeKey(key).includes(normalizedTarget))
+      if (containsMatch) {
+        return row[containsMatch]
       }
       return undefined
     }
@@ -173,15 +188,23 @@ export default defineComponent({
     }
 
     const normalizeRouteDesc = (value) => {
-      if (value === undefined || value === null || value === '') {
+      if (value === undefined || value === null) {
         return 'Unknown MAIN_ROUTE_DESC'
+      }
+      if (typeof value === 'string') {
+        const trimmed = value.trim()
+        return trimmed === '' ? 'Unknown MAIN_ROUTE_DESC' : trimmed
       }
       return value
     }
 
     const normalizePara = (value) => {
-      if (value === undefined || value === null || value === '') {
+      if (value === undefined || value === null) {
         return 'Unknown PARA'
+      }
+      if (typeof value === 'string') {
+        const trimmed = value.trim()
+        return trimmed === '' ? 'Unknown PARA' : trimmed
       }
       return value
     }
@@ -228,7 +251,8 @@ export default defineComponent({
       }
       const types = new Set()
       normalizedData.value.forEach(row => {
-        types.add(normalizeRouteDesc(extractRouteDesc(row)))
+        const routeDesc = row.MAIN_ROUTE_DESC ?? extractRouteDesc(row)
+        types.add(normalizeRouteDesc(routeDesc))
       })
       return Array.from(types).sort()
     })
@@ -239,7 +263,8 @@ export default defineComponent({
       }
       const types = new Set()
       normalizedData.value.forEach(row => {
-        types.add(normalizePara(extractPara(row) ?? row.PARA))
+        const para = row.PARA ?? extractPara(row)
+        types.add(normalizePara(para))
       })
       return Array.from(types).sort()
     })
@@ -306,7 +331,8 @@ export default defineComponent({
       const routeDesc = normalizeRouteDesc(group.routeDesc)
       const para = normalizePara(group.para)
       const groupData = normalizedData.value.filter(
-        row => normalizeRouteDesc(row.MAIN_ROUTE_DESC) === routeDesc && normalizePara(row.PARA) === para
+        row => normalizeRouteDesc(row.MAIN_ROUTE_DESC ?? extractRouteDesc(row)) === routeDesc
+          && normalizePara(row.PARA ?? extractPara(row)) === para
       )
       console.log(`PCMToTrend: MAIN_ROUTE_DESC ${routeDesc} / PARA ${para} 데이터:`, groupData)
       return groupData

--- a/src/components/PCMToTrend.vue
+++ b/src/components/PCMToTrend.vue
@@ -1,16 +1,16 @@
 <template>
   <div class="pcm-to-trend">
-    <!-- MAIN_ROUTE_DESC별로 그룹화된 차트들 -->
-    <div v-if="routeTypes.length > 1" class="multi-para-charts">
+    <!-- MAIN_ROUTE_DESC-PARA 쌍으로 그룹화된 차트들 -->
+    <div v-if="groupEntries.length > 1" class="multi-para-charts">
       <div 
-        v-for="(routeDesc, index) in routeTypes" 
-        :key="routeDesc"
+        v-for="(group, index) in groupEntries" 
+        :key="group.key"
         class="para-chart-container"
       >
         <div class="para-chart-header">
-          <h3>{{ resultTypeName }} - MAIN_ROUTE_DESC: {{ routeDesc }}</h3>
+          <h3>{{ resultTypeName }} - {{ formatGroupLabel(group) }}</h3>
           <div class="para-chart-info">
-            <span class="data-count">{{ getRouteData(routeDesc).length }} records</span>
+            <span class="data-count">{{ getGroupData(group).length }} records</span>
           </div>
         </div>
         <div 
@@ -20,12 +20,12 @@
       </div>
     </div>
     
-    <!-- 단일 MAIN_ROUTE_DESC 또는 MAIN_ROUTE_DESC 컬럼이 없는 경우 기존 로직 -->
+    <!-- 단일 MAIN_ROUTE_DESC-PARA 쌍이거나 컬럼이 없는 경우 기존 로직 -->
     <div v-else class="single-chart">
-      <div v-if="routeTypes.length === 1" class="para-chart-header">
-        <h3>{{ resultTypeName }} - MAIN_ROUTE_DESC: {{ routeTypes[0] }}</h3>
+      <div v-if="groupEntries.length === 1" class="para-chart-header">
+        <h3>{{ resultTypeName }} - {{ formatGroupLabel(groupEntries[0]) }}</h3>
         <div class="para-chart-info">
-          <span class="data-count">{{ getRouteData(routeTypes[0]).length }} records</span>
+          <span class="data-count">{{ getGroupData(groupEntries[0]).length }} records</span>
         </div>
       </div>
       <div ref="chartContainer" class="chart-container"></div>
@@ -165,39 +165,80 @@ export default defineComponent({
       return []
     })
 
-    // MAIN_ROUTE_DESC 타입별로 데이터 그룹화
-    const routeTypes = computed(() => {
+    const normalizeRouteDesc = (value) => {
+      if (value === undefined || value === null || value === '') {
+        return 'Unknown MAIN_ROUTE_DESC'
+      }
+      return value
+    }
+
+    const normalizePara = (value) => {
+      if (value === undefined || value === null || value === '') {
+        return 'Unknown PARA'
+      }
+      return value
+    }
+
+    // MAIN_ROUTE_DESC-PARA 쌍으로 데이터 그룹화
+    const groupEntries = computed(() => {
       if (!normalizedData.value || normalizedData.value.length === 0) {
         console.log('PCMToTrend - 데이터가 없음')
         return []
       }
 
-      const types = [
-        ...new Set(
-          normalizedData.value
-            .map(row => row.MAIN_ROUTE_DESC)
-            .filter(route => route !== undefined && route !== null && route !== '')
-        )
-      ]
-      console.log('PCMToTrend - MAIN_ROUTE_DESC 타입 확인:', types)
+      const groupMap = new Map()
+      normalizedData.value.forEach(row => {
+        const routeDesc = normalizeRouteDesc(row.MAIN_ROUTE_DESC)
+        const para = normalizePara(row.PARA)
+        const key = `${routeDesc}|||${para}`
+        if (!groupMap.has(key)) {
+          groupMap.set(key, { key, routeDesc, para })
+        }
+      })
+
+      const entries = Array.from(groupMap.values())
+      entries.sort((a, b) => {
+        const routeCompare = a.routeDesc.toString().localeCompare(b.routeDesc.toString())
+        if (routeCompare !== 0) {
+          return routeCompare
+        }
+        return a.para.toString().localeCompare(b.para.toString())
+      })
+
+      console.log(
+        'PCMToTrend - MAIN_ROUTE_DESC/PARA 그룹 확인:',
+        entries.map(entry => `${entry.routeDesc} - ${entry.para}`)
+      )
       console.log('PCMToTrend - 전체 데이터 개수:', normalizedData.value.length)
       console.log('PCMToTrend - 첫 번째 데이터 샘플:', normalizedData.value[0])
 
       const hasRouteCount = normalizedData.value.filter(
         row => row.MAIN_ROUTE_DESC !== undefined && row.MAIN_ROUTE_DESC !== null && row.MAIN_ROUTE_DESC !== ''
       ).length
+      const hasParaCount = normalizedData.value.filter(
+        row => row.PARA !== undefined && row.PARA !== null && row.PARA !== ''
+      ).length
       console.log(`PCMToTrend - MAIN_ROUTE_DESC 컬럼이 있는 데이터: ${hasRouteCount}/${normalizedData.value.length}`)
+      console.log(`PCMToTrend - PARA 컬럼이 있는 데이터: ${hasParaCount}/${normalizedData.value.length}`)
 
-      return types.sort()
+      return entries
     })
 
-    const getRouteData = (routeDesc) => {
+    const formatGroupLabel = (group) => {
+      return `MAIN_ROUTE_DESC: ${group.routeDesc} / PARA: ${group.para}`
+    }
+
+    const getGroupData = (group) => {
       if (!normalizedData.value || normalizedData.value.length === 0) {
         return []
       }
-      const routeData = normalizedData.value.filter(row => row.MAIN_ROUTE_DESC === routeDesc)
-      console.log(`PCMToTrend: MAIN_ROUTE_DESC ${routeDesc} 데이터:`, routeData)
-      return routeData
+      const routeDesc = normalizeRouteDesc(group.routeDesc)
+      const para = normalizePara(group.para)
+      const groupData = normalizedData.value.filter(
+        row => normalizeRouteDesc(row.MAIN_ROUTE_DESC) === routeDesc && normalizePara(row.PARA) === para
+      )
+      console.log(`PCMToTrend: MAIN_ROUTE_DESC ${routeDesc} / PARA ${para} 데이터:`, groupData)
+      return groupData
     }
 
     const setChartRef = (el, index) => {
@@ -578,34 +619,34 @@ export default defineComponent({
 
         await nextTick()
 
-        if (routeTypes.value.length > 1) {
-          // 여러 MAIN_ROUTE_DESC 타입이 있는 경우 각각 차트 생성
-          console.log(`PCMToTrend: ${routeTypes.value.length}개의 MAIN_ROUTE_DESC별 차트 생성`, routeTypes.value)
-          routeTypes.value.forEach((routeDesc, index) => {
-            const routeData = getRouteData(routeDesc)
-            console.log(`PCMToTrend: MAIN_ROUTE_DESC ${routeDesc} 데이터 개수: ${routeData.length}`)
+        if (groupEntries.value.length > 1) {
+          // 여러 MAIN_ROUTE_DESC-PARA 쌍이 있는 경우 각각 차트 생성
+          console.log(`PCMToTrend: ${groupEntries.value.length}개의 MAIN_ROUTE_DESC-PARA 쌍별 차트 생성`, groupEntries.value)
+          groupEntries.value.forEach((group, index) => {
+            const groupData = getGroupData(group)
+            console.log(`PCMToTrend: MAIN_ROUTE_DESC ${group.routeDesc} / PARA ${group.para} 데이터 개수: ${groupData.length}`)
 
-            if (routeData.length === 0) {
-              console.warn(`PCMToTrend: MAIN_ROUTE_DESC ${routeDesc}에 데이터가 없음`)
+            if (groupData.length === 0) {
+              console.warn(`PCMToTrend: MAIN_ROUTE_DESC ${group.routeDesc} / PARA ${group.para}에 데이터가 없음`)
               return
             }
             
             const container = chartRefs.value[index]
             if (container) {
-              createSingleChart(container, routeData, `${resultTypeName.value} - MAIN_ROUTE_DESC: ${routeDesc}`)
+              createSingleChart(container, groupData, `${resultTypeName.value} - ${formatGroupLabel(group)}`)
             } else {
-              console.warn(`PCMToTrend: MAIN_ROUTE_DESC ${routeDesc}의 차트 컨테이너를 찾을 수 없음`)
+              console.warn(`PCMToTrend: MAIN_ROUTE_DESC ${group.routeDesc} / PARA ${group.para}의 차트 컨테이너를 찾을 수 없음`)
             }
           })
         } else {
-          // 단일 MAIN_ROUTE_DESC 또는 MAIN_ROUTE_DESC 컬럼이 없는 경우
-          console.log('PCMToTrend: 단일 차트 생성, MAIN_ROUTE_DESC 타입:', routeTypes.value)
+          // 단일 MAIN_ROUTE_DESC-PARA 쌍 또는 컬럼이 없는 경우
+          console.log('PCMToTrend: 단일 차트 생성, MAIN_ROUTE_DESC-PARA 그룹:', groupEntries.value)
           if (chartContainer.value) {
             let dataToUse
-            if (routeTypes.value.length === 1) {
-              const firstRoute = routeTypes.value[0]
-              dataToUse = getRouteData(firstRoute)
-              console.log(`PCMToTrend: MAIN_ROUTE_DESC ${firstRoute}의 데이터 사용:`, dataToUse.length)
+            if (groupEntries.value.length === 1) {
+              const firstGroup = groupEntries.value[0]
+              dataToUse = getGroupData(firstGroup)
+              console.log(`PCMToTrend: MAIN_ROUTE_DESC ${firstGroup.routeDesc} / PARA ${firstGroup.para}의 데이터 사용:`, dataToUse.length)
             } else {
               dataToUse = normalizedData.value
               console.log('PCMToTrend: 전체 데이터 사용:', dataToUse.length)
@@ -683,7 +724,7 @@ export default defineComponent({
 
     onMounted(() => {
       console.log('PCMToTrend 마운트됨 - 기본 데이터:', props.data)
-      console.log('PCMToTrend 마운트됨 - MAIN_ROUTE_DESC 타입들:', routeTypes.value)
+      console.log('PCMToTrend 마운트됨 - MAIN_ROUTE_DESC/PARA 그룹들:', groupEntries.value)
       createCharts()
     })
 
@@ -697,9 +738,10 @@ export default defineComponent({
       chartContainer,
       chartRefs,
       normalizedData,
-      routeTypes,
+      groupEntries,
       resultTypeName,
-      getRouteData,
+      formatGroupLabel,
+      getGroupData,
       setChartRef
     }
   }

--- a/src/components/PCMToTrend.vue
+++ b/src/components/PCMToTrend.vue
@@ -143,27 +143,34 @@ export default defineComponent({
       return typeMap[props.resultType] || props.resultType
     })
 
-    const normalizedData = computed(() => {
-      if (!props.data) {
-        return []
+    const findKeyValue = (row, targetKey) => {
+      if (!row || typeof row !== 'object') {
+        return undefined
       }
-
-      if (Array.isArray(props.data)) {
-        return props.data
+      if (row[targetKey] !== undefined) {
+        return row[targetKey]
       }
-
-      if (typeof props.data === 'object' && props.data !== null) {
-        const combined = []
-        Object.values(props.data).forEach(paraData => {
-          if (Array.isArray(paraData)) {
-            combined.push(...paraData)
-          }
-        })
-        return combined
+      const normalizedTarget = targetKey.trim().toUpperCase()
+      const matchedKey = Object.keys(row).find(
+        key => key.trim().toUpperCase() === normalizedTarget
+      )
+      if (matchedKey) {
+        return row[matchedKey]
       }
+      return undefined
+    }
 
-      return []
-    })
+    const extractRouteDesc = (row) => {
+      const mainRoute = findKeyValue(row, 'MAIN_ROUTE_DESC')
+      if (mainRoute !== undefined) {
+        return mainRoute
+      }
+      return findKeyValue(row, 'MAIN_ROUTE')
+    }
+
+    const extractPara = (row) => {
+      return findKeyValue(row, 'PARA')
+    }
 
     const normalizeRouteDesc = (value) => {
       if (value === undefined || value === null || value === '') {
@@ -179,6 +186,64 @@ export default defineComponent({
       return value
     }
 
+    const normalizedData = computed(() => {
+      if (!props.data) {
+        return []
+      }
+
+      const combined = []
+      const appendRow = (row, paraKey = undefined) => {
+        if (!row || typeof row !== 'object') {
+          return
+        }
+        const routeDesc = extractRouteDesc(row)
+        const para = extractPara(row) ?? paraKey
+        combined.push({
+          ...row,
+          MAIN_ROUTE_DESC: routeDesc ?? row.MAIN_ROUTE_DESC,
+          PARA: para ?? row.PARA
+        })
+      }
+
+      if (Array.isArray(props.data)) {
+        props.data.forEach(row => appendRow(row))
+        return combined
+      }
+
+      if (typeof props.data === 'object' && props.data !== null) {
+        Object.entries(props.data).forEach(([paraKey, paraData]) => {
+          if (Array.isArray(paraData)) {
+            paraData.forEach(row => appendRow(row, paraKey))
+          }
+        })
+        return combined
+      }
+
+      return []
+    })
+
+    const routeTypes = computed(() => {
+      if (!normalizedData.value || normalizedData.value.length === 0) {
+        return []
+      }
+      const types = new Set()
+      normalizedData.value.forEach(row => {
+        types.add(normalizeRouteDesc(extractRouteDesc(row)))
+      })
+      return Array.from(types).sort()
+    })
+
+    const paraTypes = computed(() => {
+      if (!normalizedData.value || normalizedData.value.length === 0) {
+        return []
+      }
+      const types = new Set()
+      normalizedData.value.forEach(row => {
+        types.add(normalizePara(extractPara(row) ?? row.PARA))
+      })
+      return Array.from(types).sort()
+    })
+
     // MAIN_ROUTE_DESC-PARA 쌍으로 데이터 그룹화
     const groupEntries = computed(() => {
       if (!normalizedData.value || normalizedData.value.length === 0) {
@@ -186,37 +251,43 @@ export default defineComponent({
         return []
       }
 
-      const groupMap = new Map()
-      normalizedData.value.forEach(row => {
-        const routeDesc = normalizeRouteDesc(row.MAIN_ROUTE_DESC)
-        const para = normalizePara(row.PARA)
-        const key = `${routeDesc}|||${para}`
-        if (!groupMap.has(key)) {
-          groupMap.set(key, { key, routeDesc, para })
-        }
-      })
+      const routes = routeTypes.value
+      const paras = paraTypes.value
+      if (routes.length === 0 || paras.length === 0) {
+        return []
+      }
 
-      const entries = Array.from(groupMap.values())
-      entries.sort((a, b) => {
-        const routeCompare = a.routeDesc.toString().localeCompare(b.routeDesc.toString())
-        if (routeCompare !== 0) {
-          return routeCompare
-        }
-        return a.para.toString().localeCompare(b.para.toString())
+      const entries = []
+      routes.forEach(routeDesc => {
+        paras.forEach(para => {
+          entries.push({
+            key: `${routeDesc}|||${para}`,
+            routeDesc,
+            para
+          })
+        })
       })
 
       console.log(
-        'PCMToTrend - MAIN_ROUTE_DESC/PARA 그룹 확인:',
-        entries.map(entry => `${entry.routeDesc} - ${entry.para}`)
+        'PCMToTrend - MAIN_ROUTE_DESC 종류:',
+        routes
+      )
+      console.log(
+        'PCMToTrend - PARA 종류:',
+        paras
+      )
+      console.log(
+        'PCMToTrend - MAIN_ROUTE_DESC/PARA 그룹 조합 수:',
+        entries.length
       )
       console.log('PCMToTrend - 전체 데이터 개수:', normalizedData.value.length)
       console.log('PCMToTrend - 첫 번째 데이터 샘플:', normalizedData.value[0])
 
       const hasRouteCount = normalizedData.value.filter(
-        row => row.MAIN_ROUTE_DESC !== undefined && row.MAIN_ROUTE_DESC !== null && row.MAIN_ROUTE_DESC !== ''
+        row => extractRouteDesc(row) !== undefined && extractRouteDesc(row) !== null && extractRouteDesc(row) !== ''
       ).length
       const hasParaCount = normalizedData.value.filter(
-        row => row.PARA !== undefined && row.PARA !== null && row.PARA !== ''
+        row => extractPara(row) !== undefined && extractPara(row) !== null && extractPara(row) !== ''
       ).length
       console.log(`PCMToTrend - MAIN_ROUTE_DESC 컬럼이 있는 데이터: ${hasRouteCount}/${normalizedData.value.length}`)
       console.log(`PCMToTrend - PARA 컬럼이 있는 데이터: ${hasParaCount}/${normalizedData.value.length}`)
@@ -626,13 +697,13 @@ export default defineComponent({
             const groupData = getGroupData(group)
             console.log(`PCMToTrend: MAIN_ROUTE_DESC ${group.routeDesc} / PARA ${group.para} 데이터 개수: ${groupData.length}`)
 
-            if (groupData.length === 0) {
-              console.warn(`PCMToTrend: MAIN_ROUTE_DESC ${group.routeDesc} / PARA ${group.para}에 데이터가 없음`)
-              return
-            }
-            
             const container = chartRefs.value[index]
             if (container) {
+              if (groupData.length === 0) {
+                console.warn(`PCMToTrend: MAIN_ROUTE_DESC ${group.routeDesc} / PARA ${group.para}에 데이터가 없음`)
+                container.innerHTML = '<div style="padding: 20px; text-align: center; color: #666;">데이터가 없습니다.</div>'
+                return
+              }
               createSingleChart(container, groupData, `${resultTypeName.value} - ${formatGroupLabel(group)}`)
             } else {
               console.warn(`PCMToTrend: MAIN_ROUTE_DESC ${group.routeDesc} / PARA ${group.para}의 차트 컨테이너를 찾을 수 없음`)


### PR DESCRIPTION
Update `PCMToTrend.vue` to split trend graphs by `MAIN_ROUTE_DESC` instead of `PARA`.

---
<a href="https://cursor.com/background-agent?bcId=bc-19e358d3-7c5d-4280-a293-ac6f48f433f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-19e358d3-7c5d-4280-a293-ac6f48f433f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Changes**
> 
> - Groups data by `MAIN_ROUTE_DESC`–`PARA` combinations and renders one chart per group (falls back to single chart when only one group or missing columns).
> - Adds key/field normalization and tolerant extractors (`findKeyValue`, `extractRouteDesc`, `extractPara`) to support varied input shapes/keys; supports both array and object-by-PARA inputs via `normalizedData`.
> - Updates chart creation to use `getGroupData`, `groupEntries`, and dynamic titles (prefers `graphName` when provided); shows empty-state when a group has no data.
> - Improves Plotly lifecycle management (purge/cleanup), error handling, and logging; adds adaptive x-axis tick density.
> 
> **Notes**
> 
> - Public API unchanged, but grouping and rendering logic significantly refactored.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dad9c82c1c0e6e2b7bb8047402d18cda68e6cd8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->